### PR TITLE
fix: correct nightly tag, fix tmux startup, full-word suggestions only, and keep current dir on reload

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,6 +29,7 @@ jobs:
         id: version
         run: |
           BASE=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          BASE=${BASE%%-nightly*}
           SHORT=$(git rev-parse --short HEAD)
           echo "version=${BASE}-nightly.${SHORT}" >> $GITHUB_OUTPUT
 

--- a/integration/history.go
+++ b/integration/history.go
@@ -145,8 +145,10 @@ func SearchHistory(query string) ([]HistResult, error) {
 	// when query has a clear first word, only keep history entries that share the same first word
 	// this prevents e.g. curl commands from showing up when typing "git ..."
 	queryFirstWord := ""
-	if fields := strings.Fields(query); len(fields) > 0 {
-		queryFirstWord = strings.ToLower(fields[0])
+	if strings.IndexByte(query, ' ') != -1 {
+		if fields := strings.Fields(query); len(fields) > 0 {
+			queryFirstWord = strings.ToLower(fields[0])
+		}
 	}
 
 	var results []HistResult

--- a/root/init.go
+++ b/root/init.go
@@ -23,6 +23,12 @@ For example, add this to your ~/.zshrc:
 		case "bash", "zsh":
 			fmt.Printf(`
 # Iris Autostart Hook
+if [ -n "$TMUX" ] && [ -n "$IRIS_PID" ]; then
+    if ps -o comm= -p $PPID 2>/dev/null | grep -q "tmux"; then
+        unset IRIS_PID IRIS_IS_CHILD IRIS_FD
+    fi
+fi
+
 if [ -z "$IRIS_PID" ]; then
     export IRIS_ACTIVE_SHELL="%s"
     exec iris
@@ -31,6 +37,14 @@ fi
 		case "fish":
 			fmt.Printf(`
 # Iris Autostart Hook
+if set -q TMUX; and set -q IRIS_PID
+    if ps -o comm= -p $PPID 2>/dev/null | grep -q "tmux"
+        set -e IRIS_PID
+        set -e IRIS_IS_CHILD
+        set -e IRIS_FD
+    end
+end
+
 if not set -q IRIS_PID
     set -gx IRIS_ACTIVE_SHELL "fish"
     exec iris

--- a/root/wrapper.go
+++ b/root/wrapper.go
@@ -160,6 +160,9 @@ func runWrapper() {
 				}
 
 				if c.Process != nil {
+					if cwd, err := os.Readlink(fmt.Sprintf("/proc/%d/cwd", c.Process.Pid)); err == nil {
+						_ = os.Chdir(cwd)
+					}
 					_ = syscall.Kill(c.Process.Pid, syscall.SIGKILL)
 					_ = ptmx.Close()
 				}


### PR DESCRIPTION
- correct nightly release tag name f58ed5837984625d39eb9fd03a8e6cf2c1c1d663
- iris not start in tmux ebcdaa57dc25748d3406c2a9f49a6b5f18d73fe9
- suggestions only show on full word typing 35715fb1faed98357b29147b64c983ef4bc483e9
- keep current dir on reload instead of return home dir 8cb03e474fa0a03e856bf5f750180b114a40fb3d