### PR TITLE
fix(wrapper): skip alias expansion on paste

### DIFF
--- a/root/wrapper.go
+++ b/root/wrapper.go
@@ -557,6 +557,7 @@ func runWrapper() {
 
 		if n > 0 {
 			if isExecuting() {
+				inBracketedPaste = false
 				_, _ = ptmx.Write(inputSlice[:n])
 				continue
 			}
@@ -573,11 +574,7 @@ func runWrapper() {
 					if i+5 < n && inputSlice[i+1] == '[' && inputSlice[i+2] == '2' && inputSlice[i+3] == '0' {
 						if (inputSlice[i+4] == '0' || inputSlice[i+4] == '1') && inputSlice[i+5] == '~' {
 							intercepted = true
-							if inputSlice[i+4] == '0' {
-								inBracketedPaste = true
-							} else {
-								inBracketedPaste = false
-							}
+							inBracketedPaste = inputSlice[i+4] == '0'
 							logger.Debugf("Intercepted bracketed paste event inPaste=%v", inBracketedPaste)
 							_, _ = ptmx.Write(inputSlice[i : i+6])
 							i += 5
@@ -953,6 +950,7 @@ func runWrapper() {
 						shouldOverlayDraw = true
 						userNavigated.Store(false)
 					case '\r', '\n', 0x03, 0x15: // enter, ctrl+c, ctrl+u: clear buffer on line reset
+						inBracketedPaste = false
 						bufferMu.Lock()
 						naiveBuffer = ""
 						cursorOffset = 0

--- a/root/wrapper.go
+++ b/root/wrapper.go
@@ -547,6 +547,7 @@ func runWrapper() {
 	// for most cases, I just handle the already have terminal shortcuts
 	// for some shortcuts like tab, enter, shift tab, ctrl r,
 	// they have a little bit different behavior to match our tool
+	inBracketedPaste := false
 	for {
 		inputSlice := make([]byte, 128)
 		n, err := os.Stdin.Read(inputSlice)
@@ -572,7 +573,12 @@ func runWrapper() {
 					if i+5 < n && inputSlice[i+1] == '[' && inputSlice[i+2] == '2' && inputSlice[i+3] == '0' {
 						if (inputSlice[i+4] == '0' || inputSlice[i+4] == '1') && inputSlice[i+5] == '~' {
 							intercepted = true
-							logger.Debugf("Intercepted bracketed paste event")
+							if inputSlice[i+4] == '0' {
+								inBracketedPaste = true
+							} else {
+								inBracketedPaste = false
+							}
+							logger.Debugf("Intercepted bracketed paste event inPaste=%v", inBracketedPaste)
 							_, _ = ptmx.Write(inputSlice[i : i+6])
 							i += 5
 							continue
@@ -961,9 +967,9 @@ func runWrapper() {
 					default:
 						// track normal printable characters in the buffer for matching
 						if b >= 32 && b <= 126 {
-							// if user presses space, check if the current word is an alias
+							// expand alias on space, but only when typing manually (not pasting)
 							bufferMu.Lock()
-							isSpaceAlias := b == ' ' && naiveBuffer != "" && !strings.Contains(naiveBuffer, " ")
+							isSpaceAlias := !inBracketedPaste && b == ' ' && naiveBuffer != "" && !strings.Contains(naiveBuffer, " ")
 							var target string
 							var ok bool
 							if isSpaceAlias {


### PR DESCRIPTION
When you paste text in most modern terminals (Alacritty, iTerm2, Kitty, WezTerm...), the terminal enables bracketed paste mode and wraps the pasted content between two control strings:

`\x1b[200~` --> start pasting
`\x1b[201~` --> end pasting
Previously, iris detected these two strings but didn't track the state. Now I have:

Declared `inBracketedPaste := false` before the stdin loop
Set `inBracketedPaste = true` when receiving `\x1b[200~`, `false` when receiving `\x1b[201~`
Checked `!inBracketedPaste` before triggering the alias expansion
reset `inBracketedPaste` on enter/ctrl-c/ctrl-u and when executing