### PR TITLE
Fix stdin handling and exit command in fish shell

### DIFF
--- a/root/crash.go
+++ b/root/crash.go
@@ -20,7 +20,8 @@ func startRescueShell() {
 	if shell == "" {
 		shell = "/bin/sh"
 	}
-	_ = syscall.Exec(shell, []string{shell}, os.Environ())
+	env := append(os.Environ(), "IRIS_RESCUE=1")
+	_ = syscall.Exec(shell, []string{shell}, env)
 }
 
 var (

--- a/root/init.go
+++ b/root/init.go
@@ -30,7 +30,7 @@ if [ -n "$TMUX" ] && [ -n "$IRIS_PID" ]; then
     fi
 fi
 
-if [ -z "$IRIS_PID" ]; then
+if [ -z "$IRIS_PID" ] && [ -z "$IRIS_RESCUE" ]; then
     export IRIS_ACTIVE_SHELL="zsh"
     exec iris
 fi
@@ -66,7 +66,7 @@ if [ -n "$TMUX" ] && [ -n "$IRIS_PID" ]; then
     fi
 fi
 
-if [ -z "$IRIS_PID" ]; then
+if [ -z "$IRIS_PID" ] && [ -z "$IRIS_RESCUE" ]; then
     export IRIS_ACTIVE_SHELL="bash"
     exec iris
 fi
@@ -82,7 +82,7 @@ if set -q TMUX; and set -q IRIS_PID
     end
 end
 
-if status is-interactive; and not set -q IRIS_PID
+if status is-interactive; and not set -q IRIS_PID; and not set -q IRIS_RESCUE
     set -gx IRIS_ACTIVE_SHELL "fish"
     exec iris
 end

--- a/root/init.go
+++ b/root/init.go
@@ -169,8 +169,8 @@ var setupCmd = &cobra.Command{
 			} else {
 				newContent = "# Iris Autocomplete\n" + evalCmd + "\n"
 			}
-			if err := os.MkdirAll(filepath.Dir(configFile), 0755); err != nil {
-				fmt.Printf("Failed to create directory for %s: %v\n", configFile, err)
+			if mkdirErr := os.MkdirAll(filepath.Dir(configFile), 0755); mkdirErr != nil {
+				fmt.Printf("Failed to create directory for %s: %v\n", configFile, mkdirErr)
 				return
 			}
 			err = os.WriteFile(configFile, []byte(newContent), 0644)

--- a/root/init.go
+++ b/root/init.go
@@ -82,9 +82,19 @@ if set -q TMUX; and set -q IRIS_PID
     end
 end
 
-if not set -q IRIS_PID
+if status is-interactive; and not set -q IRIS_PID
     set -gx IRIS_ACTIVE_SHELL "fish"
     exec iris
+end
+
+# Iris Autocomplete Hook
+if set -q IRIS_PID; and set -q IRIS_FD
+    function _iris_fish_postexec --on-event fish_postexec
+        echo -n -e "IRIS_CMD_STOP\x00" >&$IRIS_FD 2>/dev/null
+    end
+    function _iris_fish_preexec --on-event fish_preexec
+        echo -n -e "IRIS_CMD_START\x00" >&$IRIS_FD 2>/dev/null
+    end
 end
 `)
 		}
@@ -148,19 +158,22 @@ var setupCmd = &cobra.Command{
 			return
 		}
 
-		content, _ := os.ReadFile(configFile)
+		content, readErr := os.ReadFile(configFile)
 		if strings.Contains(string(content), "iris init") {
 			fmt.Printf("Iris is already configured in %s\n", configFile)
 		} else {
-			f, err := os.OpenFile(configFile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+			var newContent string
+			if readErr == nil && len(content) > 0 {
+				newContent = "# Iris Autocomplete\n" + evalCmd + "\n\n" + string(content)
+			} else {
+				newContent = "# Iris Autocomplete\n" + evalCmd + "\n"
+			}
+			err = os.WriteFile(configFile, []byte(newContent), 0644)
 			if err != nil {
 				fmt.Printf("Failed to update %s: %v\n", configFile, err)
 				return
 			}
-			defer func() { _ = f.Close() }()
-
-			_, _ = f.WriteString("\n# Iris Autocomplete\n" + evalCmd + "\n")
-			fmt.Printf("✓ Added iris integration to %s\n", configFile)
+			fmt.Printf("✓ Added iris integration to top of %s\n", configFile)
 		}
 
 		// initialize default config file if it does not exist

--- a/root/init.go
+++ b/root/init.go
@@ -168,6 +168,10 @@ var setupCmd = &cobra.Command{
 			} else {
 				newContent = "# Iris Autocomplete\n" + evalCmd + "\n"
 			}
+			if err := os.MkdirAll(filepath.Dir(configFile), 0755); err != nil {
+				fmt.Printf("Failed to create directory for %s: %v\n", configFile, err)
+				return
+			}
 			err = os.WriteFile(configFile, []byte(newContent), 0644)
 			if err != nil {
 				fmt.Printf("Failed to update %s: %v\n", configFile, err)

--- a/root/root.go
+++ b/root/root.go
@@ -98,7 +98,7 @@ func runWatchdog() {
 
 	cmdStdin := os.Stdin
 	if !term.IsTerminal(int(cmdStdin.Fd())) {
-		if tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0); err == nil {
+		if tty, ttyErr := os.OpenFile("/dev/tty", os.O_RDWR, 0); ttyErr == nil {
 			cmdStdin = tty
 		}
 	}

--- a/root/root.go
+++ b/root/root.go
@@ -80,13 +80,20 @@ func runWatchdog() {
 		return
 	}
 
+	cmdStdin := os.Stdin
+	if !term.IsTerminal(int(cmdStdin.Fd())) {
+		if tty, ttyErr := os.OpenFile("/dev/tty", os.O_RDWR, 0); ttyErr == nil {
+			cmdStdin = tty
+		}
+	}
+
 	// save original terminal settings in parent process if Stdin is a terminal
 	var watchdogOldState *term.State
-	if term.IsTerminal(int(os.Stdin.Fd())) {
+	if term.IsTerminal(int(cmdStdin.Fd())) {
 		var errState error
-		watchdogOldState, errState = term.MakeRaw(int(os.Stdin.Fd()))
+		watchdogOldState, errState = term.MakeRaw(int(cmdStdin.Fd()))
 		if errState == nil {
-			_ = term.Restore(int(os.Stdin.Fd()), watchdogOldState)
+			_ = term.Restore(int(cmdStdin.Fd()), watchdogOldState)
 		}
 	}
 
@@ -94,13 +101,6 @@ func runWatchdog() {
 	if err != nil {
 		runOriginal()
 		return
-	}
-
-	cmdStdin := os.Stdin
-	if !term.IsTerminal(int(cmdStdin.Fd())) {
-		if tty, ttyErr := os.OpenFile("/dev/tty", os.O_RDWR, 0); ttyErr == nil {
-			cmdStdin = tty
-		}
 	}
 
 	cmd := exec.CommandContext(context.Background(), exe, os.Args[1:]...)
@@ -171,7 +171,7 @@ func runWatchdog() {
 			WriteCrashLog(string(content))
 			// restore terminal state if watchdog saved it
 			if watchdogOldState != nil {
-				_ = term.Restore(int(os.Stdin.Fd()), watchdogOldState)
+				_ = term.Restore(int(cmdStdin.Fd()), watchdogOldState)
 			}
 			printCrashNotice()
 			startRescueShell()

--- a/root/root.go
+++ b/root/root.go
@@ -80,10 +80,14 @@ func runWatchdog() {
 		return
 	}
 
-	// save original terminal settings in parent process
-	watchdogOldState, errState := term.MakeRaw(int(os.Stdin.Fd()))
-	if errState == nil {
-		_ = term.Restore(int(os.Stdin.Fd()), watchdogOldState)
+	// save original terminal settings in parent process if Stdin is a terminal
+	var watchdogOldState *term.State
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		var errState error
+		watchdogOldState, errState = term.MakeRaw(int(os.Stdin.Fd()))
+		if errState == nil {
+			_ = term.Restore(int(os.Stdin.Fd()), watchdogOldState)
+		}
 	}
 
 	r, w, err := os.Pipe()
@@ -92,9 +96,16 @@ func runWatchdog() {
 		return
 	}
 
+	cmdStdin := os.Stdin
+	if !term.IsTerminal(int(cmdStdin.Fd())) {
+		if tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0); err == nil {
+			cmdStdin = tty
+		}
+	}
+
 	cmd := exec.CommandContext(context.Background(), exe, os.Args[1:]...)
 	cmd.Env = append(os.Environ(), "IRIS_IS_CHILD=true")
-	cmd.Stdin = os.Stdin
+	cmd.Stdin = cmdStdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = w
 

--- a/root/wrapper.go
+++ b/root/wrapper.go
@@ -84,6 +84,7 @@ func saveMode(mode string) {
 
 var (
 	oldState     *term.State
+	oldStateFd   int
 	oldStateMu   sync.Mutex
 	activeMode   string
 	activeModeMu sync.RWMutex
@@ -104,7 +105,7 @@ func restoreTerminal() {
 	oldStateMu.Lock()
 	defer oldStateMu.Unlock()
 	if oldState != nil {
-		_ = term.Restore(int(os.Stdin.Fd()), oldState)
+		_ = term.Restore(oldStateFd, oldState)
 		oldState = nil
 	}
 }
@@ -155,7 +156,7 @@ func runWrapper() {
 
 	stdinFile := os.Stdin
 	if !term.IsTerminal(int(stdinFile.Fd())) {
-		if tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0); err == nil {
+		if tty, ttyErr := os.OpenFile("/dev/tty", os.O_RDWR, 0); ttyErr == nil {
 			stdinFile = tty
 		}
 	}
@@ -173,6 +174,7 @@ func runWrapper() {
 			logger.Errorf("Failed to set terminal raw mode: %v", errMakeRaw)
 			panic(errMakeRaw)
 		}
+		oldStateFd = int(stdinFile.Fd())
 		logger.Debugf("Terminal set to raw mode successfully")
 		defer func() {
 			oldStateMu.Lock()

--- a/root/wrapper.go
+++ b/root/wrapper.go
@@ -343,7 +343,7 @@ func runWrapper() {
 
 	var disableGhostText atomic.Bool
 	disableGhostText.Store(!config.Get().UI.GhostText)
-	var renderOverlay func() = func() {}
+	renderOverlay := func() {}
 
 	// listen for suggestion requests from shell scripts via the ipc pipe
 	go func() {

--- a/root/wrapper.go
+++ b/root/wrapper.go
@@ -304,12 +304,12 @@ func runWrapper() {
 		for {
 			n, err := ptmx.Read(buf)
 			if err != nil {
+				restoreTerminal()
 				if err == io.EOF || errors.Is(err, syscall.EIO) || strings.Contains(err.Error(), "input/output error") {
-					restoreTerminal()
 					os.Exit(0)
 				}
-				restoreTerminal()
-				os.Exit(0)
+				logger.Errorf("Unexpected PTY read error: %v", err)
+				os.Exit(1)
 			}
 			writeStdout(buf[:n])
 

--- a/root/wrapper.go
+++ b/root/wrapper.go
@@ -335,7 +335,7 @@ func runWrapper() {
 
 	var disableGhostText atomic.Bool
 	disableGhostText.Store(!config.Get().UI.GhostText)
-	var renderOverlay func()
+	var renderOverlay func() = func() {}
 
 	// listen for suggestion requests from shell scripts via the ipc pipe
 	go func() {

--- a/root/wrapper.go
+++ b/root/wrapper.go
@@ -284,7 +284,7 @@ func runWrapper() {
 	config.AutoDetectConfigChange(func(cfg *config.Config) {
 		disableGhostText.Store(!cfg.UI.GhostText)
 	})
-	var renderOverlay func()
+	renderOverlay := func() {}
 	isExecuting := func() bool {
 		if isCommandActive.Load() {
 			return true
@@ -341,9 +341,7 @@ func runWrapper() {
 		}
 	}()
 
-	var disableGhostText atomic.Bool
-	disableGhostText.Store(!config.Get().UI.GhostText)
-	renderOverlay := func() {}
+
 
 	// listen for suggestion requests from shell scripts via the ipc pipe
 	go func() {

--- a/root/wrapper.go
+++ b/root/wrapper.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -297,11 +298,12 @@ func runWrapper() {
 		for {
 			n, err := ptmx.Read(buf)
 			if err != nil {
-				if err == io.EOF {
+				if err == io.EOF || errors.Is(err, syscall.EIO) || strings.Contains(err.Error(), "input/output error") {
 					restoreTerminal()
 					os.Exit(0)
 				}
-				continue
+				restoreTerminal()
+				os.Exit(0)
 			}
 			writeStdout(buf[:n])
 

--- a/root/wrapper.go
+++ b/root/wrapper.go
@@ -167,20 +167,24 @@ func runWrapper() {
 
 	// put terminal in raw mode to intercept every keystroke
 	var errMakeRaw error
-	oldState, errMakeRaw = term.MakeRaw(int(stdinFile.Fd()))
-	if errMakeRaw != nil {
-		logger.Errorf("Failed to set terminal raw mode: %v", errMakeRaw)
-		panic(errMakeRaw)
-	}
-	logger.Debugf("Terminal set to raw mode successfully")
-	defer func() {
-		oldStateMu.Lock()
-		defer oldStateMu.Unlock()
-		if oldState != nil {
-			_ = term.Restore(int(stdinFile.Fd()), oldState)
-			oldState = nil
+	if term.IsTerminal(int(stdinFile.Fd())) {
+		oldState, errMakeRaw = term.MakeRaw(int(stdinFile.Fd()))
+		if errMakeRaw != nil {
+			logger.Errorf("Failed to set terminal raw mode: %v", errMakeRaw)
+			panic(errMakeRaw)
 		}
-	}()
+		logger.Debugf("Terminal set to raw mode successfully")
+		defer func() {
+			oldStateMu.Lock()
+			defer oldStateMu.Unlock()
+			if oldState != nil {
+				_ = term.Restore(int(stdinFile.Fd()), oldState)
+				oldState = nil
+			}
+		}()
+	} else {
+		logger.Warnf("stdinFile is not a terminal, skipping raw mode")
+	}
 
 	sigCh := make(chan os.Signal, 2)
 	signal.Notify(sigCh, syscall.SIGWINCH, syscall.SIGUSR1)

--- a/root/wrapper.go
+++ b/root/wrapper.go
@@ -152,20 +152,34 @@ func runWrapper() {
 	}
 	defer func() { _ = ptmx.Close() }()
 
-	_ = pty.InheritSize(os.Stdin, ptmx)
+	stdinFile := os.Stdin
+	if !term.IsTerminal(int(stdinFile.Fd())) {
+		if tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0); err == nil {
+			stdinFile = tty
+		}
+	}
+
+	_ = pty.InheritSize(stdinFile, ptmx)
 	spec.ShellPID = c.Process.Pid
 
 	logger.Infof("PTY child shell started: shell=%s, path=%s, pid=%d", shellName, adapter.GetShellPath(), c.Process.Pid)
 
 	// put terminal in raw mode to intercept every keystroke
 	var errMakeRaw error
-	oldState, errMakeRaw = term.MakeRaw(int(os.Stdin.Fd()))
+	oldState, errMakeRaw = term.MakeRaw(int(stdinFile.Fd()))
 	if errMakeRaw != nil {
 		logger.Errorf("Failed to set terminal raw mode: %v", errMakeRaw)
 		panic(errMakeRaw)
 	}
 	logger.Debugf("Terminal set to raw mode successfully")
-	defer restoreTerminal()
+	defer func() {
+		oldStateMu.Lock()
+		defer oldStateMu.Unlock()
+		if oldState != nil {
+			_ = term.Restore(int(stdinFile.Fd()), oldState)
+			oldState = nil
+		}
+	}()
 
 	sigCh := make(chan os.Signal, 2)
 	signal.Notify(sigCh, syscall.SIGWINCH, syscall.SIGUSR1)
@@ -183,7 +197,7 @@ func runWrapper() {
 			switch s {
 			case syscall.SIGWINCH:
 				logger.Debugf("Received SIGWINCH terminal resize signal")
-				_ = pty.InheritSize(os.Stdin, ptmx) // handle terminal window resize
+				_ = pty.InheritSize(stdinFile, ptmx) // handle terminal window resize
 			// this is the core feature of reloading
 			// it helps IRIS reload itself that you dont need to restart the shell manually
 			// SIGUSR1 is the signal to active reload when you type "just reload"
@@ -595,7 +609,7 @@ func runWrapper() {
 	inBracketedPaste := false
 	for {
 		inputSlice := make([]byte, 128)
-		n, err := os.Stdin.Read(inputSlice)
+		n, err := stdinFile.Read(inputSlice)
 		if err != nil {
 			break
 		}


### PR DESCRIPTION
### Summary of Changes                                                                                                                                                         
                                                                                                                                                                                   
Fixes **#53** (*Fish shell integration panics with `inappropriate ioctl for device`*).                                                                                         
                                                                                                                                                                                   
#### 1. Fixed Non-TTY Stdin (`panic: inappropriate ioctl for device`) — Fixes #53                                                                                              
   - **Root Cause**: When executing `iris init fish | source` (or sourcing shell configs), `os.Stdin` (FD 0) is connected to a pipe instead of a TTY. Calling `term.MakeRaw()` on 
  a pipe returns `ENOTTY`.                                                                                                                                                         
   - **Fix**: Guarded `term.MakeRaw()` with `term.IsTerminal()` checks across `root/wrapper.go` and `root/root.go`. Added fallback to open and use `/dev/tty` when `os.Stdin` is  
  not a terminal device.
   - **Fish IPC Hooks**: Added `fish_preexec` and `fish_postexec` event handlers to `iris init fish` to send `IRIS_CMD_START` / `IRIS_CMD_STOP` IPC signals over `$IRIS_FD`.      
  
#### 2. Fixed Shell Setup Order (Duplicate `fastfetch` / startup executions) — Fixes #53
   - **Root Cause**: `iris setup` appended the init script to the bottom of shell configs (`config.fish`, `.zshrc`, `.bashrc`), causing pre-existing interactive startup commands 
  to run twice.
   - **Fix**: Updated `setupCmd` in `root/init.go` to **prepend** `# Iris Autocomplete` to the top of shell configuration files.
  
#### 3. Fixed Terminal Exit Loop Handling — Relates to #50
   - **Root Cause**: When typing `exit` in the wrapped shell, Linux PTY returns `syscall.EIO` (`Input/output error`) on `ptmx.Read()` rather than `io.EOF`. `runWrapper()` was    
  ignoring non-EOF errors and looping indefinitely without restoring the terminal or calling `os.Exit(0)`.
   - **Fix**: Updated the `ptmx.Read` error handler in `root/wrapper.go` to handle `syscall.EIO` and exit cleanly.
  
   ---
  
  ### Issues Addressed
   - Closes #53
   - Relates to #50, #55
  
   ---
  
  ### Verification Tested
   - [x] Verified `iris setup fish` / `iris init fish | source` initializes without `ioctl` panic.
   - [x] Verified typing `exit` in Fish, Zsh, and Bash terminates IRIS cleanly and restores standard terminal state.
   - [x] Ran `go test ./...` — all tests pass.