### PR TITLE
fix: arrow up history entries

### DIFF
--- a/root/wrapper.go
+++ b/root/wrapper.go
@@ -411,7 +411,6 @@ func runWrapper() {
 				lastSubmittedCommand = ""
 				bufferMu.Unlock()
 				if cmdToRecord != "" {
-					integration.RecordSessionCommand(cmdToRecord)
 					cwd := spec.GetCWD()
 					prevSkeleton, prevCwd := getPrevRecordedInfo()
 					currSkeleton := scoring.ExtractSkeleton(cmdToRecord)
@@ -943,13 +942,14 @@ func runWrapper() {
 						continue
 					}
 
-					isCommandActive.Store(true)
-					_, _ = ptmx.Write([]byte{b})
+					integration.RecordSessionCommand(cmdToSubmit)
 					bufferMu.Lock()
 					lastSubmittedCommand = strings.TrimSpace(cmdToSubmit)
 					naiveBuffer = ""
 					cursorOffset = 0
 					bufferMu.Unlock()
+					isCommandActive.Store(true)
+					_, _ = ptmx.Write([]byte{b})
 					disableGhostText.Store(false)
 					shouldOverlayDraw = false
 					userNavigated.Store(false)


### PR DESCRIPTION
Closes #76 

Session history was recorded only after receiving `IRIS_CMD_STOP`. Directly launched Bash sessions may not install that completion hook, and Bash does not flush `.bash_history` until the shell exits.

There was also a race where `Enter` was sent to the shell before Iris stored the submitted command, allowing fast commands to finish before the command was captured.

The fix is

- Record commands in session history immediately when they are submitted.
- Store the submitted command before sending Enter to the shell.
- Keep command-completion handling responsible for exit-code and frecency data.

Once again (and please tell me if you prefer not) I'm not fluent in `go` so this was all Sol