### PR TITLE
fix(history): respect zdotdir config for history

### DIFF
--- a/integration/history.go
+++ b/integration/history.go
@@ -68,9 +68,9 @@ func SearchHistory(query string, aliases map[string]string) ([]HistResult, error
 	var histFile string
 	switch shellName {
 	case "zsh":
-		histFile = filepath.Join(home, ".zsh_history")
+		histFile = filepath.Join(shell.GetZshConfigDir(), ".zsh_history")
 	case "fish":
-		histFile = filepath.Join(home, ".local", "share", "fish", "fish_history")
+		histFile = filepath.Join(shell.GetFishDataDir(), "fish_history")
 	default:
 		histFile = filepath.Join(home, ".bash_history")
 	}

--- a/integration/history.go
+++ b/integration/history.go
@@ -66,13 +66,17 @@ func SearchHistory(query string, aliases map[string]string) ([]HistResult, error
 	}
 
 	var histFile string
-	switch shellName {
-	case "zsh":
-		histFile = filepath.Join(shell.GetZshConfigDir(), ".zsh_history")
-	case "fish":
-		histFile = filepath.Join(shell.GetFishDataDir(), "fish_history")
-	default:
-		histFile = filepath.Join(home, ".bash_history")
+	if envHist := os.Getenv("HISTFILE"); envHist != "" {
+		histFile = envHist
+	} else {
+		switch shellName {
+		case "zsh":
+			histFile = filepath.Join(shell.GetZshConfigDir(), ".zsh_history")
+		case "fish":
+			histFile = filepath.Join(shell.GetFishDataDir(), "fish_history")
+		default:
+			histFile = filepath.Join(home, ".bash_history")
+		}
 	}
 
 	if info, err := os.Stat(histFile); err == nil {

--- a/integration/shell/adapter.go
+++ b/integration/shell/adapter.go
@@ -125,6 +125,14 @@ func GetFishConfigDir() string {
 	return filepath.Join(home, ".config", "fish")
 }
 
+func GetFishDataDir() string {
+	if xdg := os.Getenv("XDG_DATA_HOME"); xdg != "" {
+		return filepath.Join(xdg, "fish")
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".local", "share", "fish")
+}
+
 func ScanPosixAliases(files []string) map[string]string {
 	aliases := make(map[string]string)
 	home, err := os.UserHomeDir()


### PR DESCRIPTION
closes #82

Also added a `HISTFILE` so it always reads the correct file that the shell is pointing to

Is there a `HISTFILE`? If so, use it
If it's Zsh: Is there a `ZDOTDIR`? Use `ZDOTDIR/.zsh_history`
If it's Fish: Is there an `XDG_DATA_HOME`? Use `XDG_DATA_HOME/fish/fish_history`
If none of them are present, revert to the default `$HOME/...`