### PR TITLE
fix: update stale vendorHash after lipgloss v2 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ If you are using Nix Flakes, you can consume this module directly without buildi
 
    **Option B: Install to your user profile**
    ```bash
-   nix profile install github:versenilvis/iris
+   nix profile add github:versenilvis/iris
    ```
 
    **Option C: Using Home Manager**

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
               subPackages = ["cmd/iris"];
 
               proxyVendor = true;
-              vendorHash = "sha256-kBSMhUsuCKIjAXjGfl1WSjCX+tlGi9BTnkRu9ScW6M0=";
+              vendorHash = "sha256-KQNloP/Aj283YQ4d5LFu/2Pbb2HbVTZPhLK1fs4xvGw=";
 
               doCheck = false;
 


### PR DESCRIPTION
Commit `efc49ba` (feat: upgrade to lipgloss v2, #94) changed `go.mod`/`go.sum` (lipgloss v1 → v2, ~24 dependency version bumps) but did not update `vendorHash` in `flake.nix`.

As a result `nix build .#iris` (and any consumer) fails with a fixed-output derivation hash mismatch:

```
error: hash mismatch in fixed-output derivation 'iris-<rev>-go-modules.drv':
         specified: sha256-kBSMhUsuCKIjAXjGfl1WSjCX+tlGi9BTnkRu9ScW6M0=
            got:    sha256-KQNloP/Aj283YQ4d5LFu/2Pbb2HbVTZPhLK1fs4xvGw=
```

This one-line change updates `vendorHash` to the hash actually produced by the module set at HEAD. Verified: `nix build .#iris` succeeds with the corrected hash.

Run `nix flake update` afterwards to regenerate `flake.lock`.