### PR TITLE
feat(shell): follow `source` lines when scanning aliases

### DIFF
--- a/commands/fs/broot.go
+++ b/commands/fs/broot.go
@@ -8,6 +8,7 @@ func init() {
 	spec.Register(&spec.Spec{
 		Name:        "broot",
 		Description: "Show the last modified date of files and directories",
+		Generator:   spec.FileGenerator("/"),
 		Options: []spec.Option{
 			{Name: "--dates", Description: "Show the last modified date of files and directories"},
 			{Name: "--no-dates", Description: "Don't show the last modified date"},

--- a/commands/fs/dust.go
+++ b/commands/fs/dust.go
@@ -8,6 +8,7 @@ func init() {
 	spec.Register(&spec.Spec{
 		Name:        "dust",
 		Description: "Like du but more intuitive",
+		Generator:   spec.FileGenerator("/"),
 		Options: []spec.Option{
 			{Name: "--help", Description: "Show help for dust"},
 			{Name: "--version", Description: "Print version information"},

--- a/commands/fs/exa.go
+++ b/commands/fs/exa.go
@@ -8,5 +8,6 @@ func init() {
 	spec.Register(&spec.Spec{
 		Name:        "exa",
 		Description: "A modern replacement for ls",
+		Generator:   spec.FileGenerator(),
 	})
 }

--- a/commands/fs/eza.go
+++ b/commands/fs/eza.go
@@ -8,6 +8,7 @@ func init() {
 	spec.Register(&spec.Spec{
 		Name:        "eza",
 		Description: "A modern replacement for ls",
+		Generator:   spec.FileGenerator(),
 		Options: []spec.Option{
 			{Name: "-?", Description: "Show list of command-line options"},
 			{Name: "-v", Description: "Show version of eza"},

--- a/commands/fs/lsd.go
+++ b/commands/fs/lsd.go
@@ -8,6 +8,7 @@ func init() {
 	spec.Register(&spec.Spec{
 		Name:        "lsd",
 		Description: "An ls command with a lot of pretty colors and some other stuff",
+		Generator:   spec.FileGenerator(),
 		Options: []spec.Option{
 			{Name: "-1", Description: "Display one entry per line"},
 			{Name: "-A", Description: "Do not list implied . and"},

--- a/commands/fs/mkdir.go
+++ b/commands/fs/mkdir.go
@@ -8,6 +8,7 @@ func init() {
 	spec.Register(&spec.Spec{
 		Name:        "mkdir",
 		Description: "make directories",
+		Generator:   spec.FileGenerator("/"),
 		Options: []spec.Option{
 			{Name: "-p", Description: "create parent dirs"},
 			{Name: "-v", Description: "verbose"},

--- a/commands/fs/rmdir.go
+++ b/commands/fs/rmdir.go
@@ -8,6 +8,7 @@ func init() {
 	spec.Register(&spec.Spec{
 		Name:        "rmdir",
 		Description: "Remove directories",
+		Generator:   spec.FileGenerator("/"),
 		Options: []spec.Option{
 			{Name: "-p", Description: "Remove each directory of path"},
 		},

--- a/commands/fs/trash.go
+++ b/commands/fs/trash.go
@@ -8,6 +8,7 @@ func init() {
 	spec.Register(&spec.Spec{
 		Name:        "trash",
 		Description: "Trash, move files/folders to the trash",
+		Generator:   spec.FileGenerator(),
 		Options: []spec.Option{
 			{Name: "-v", Description: "Print verbose output while moving items"},
 			{Name: "-F", Description: "Use the Finder API to move items to the trash"},

--- a/commands/fs/tree.go
+++ b/commands/fs/tree.go
@@ -8,6 +8,7 @@ func init() {
 	spec.Register(&spec.Spec{
 		Name:        "tree",
 		Description: "Display directories as trees (with optional color/HTML output)",
+		Generator:   spec.FileGenerator("/"),
 		Options: []spec.Option{
 			{Name: "-a", Description: "All files are listed"},
 			{Name: "-d", Description: "List directories only"},

--- a/integration/shell/adapter.go
+++ b/integration/shell/adapter.go
@@ -7,7 +7,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -84,22 +86,31 @@ func GetZshConfigDir() string {
 	if zdotdir := os.Getenv("ZDOTDIR"); zdotdir != "" {
 		return zdotdir
 	}
-	
-	// Fallback: ask zsh directly in case ZDOTDIR is set in ~/.zshenv without export
-	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, "zsh", "-c", "echo $ZDOTDIR")
-	out, err := cmd.Output()
-	if err == nil {
-		zdotdir := strings.TrimSpace(string(out))
-		if zdotdir != "" {
-			return zdotdir
+
+	// Fallback: ask zsh directly in case ZDOTDIR is set in ~/.zshenv without
+	// export. ScanAliases runs on every keystroke, so this is resolved once per
+	// process -- ZDOTDIR can't change under a running iris, and paying for a
+	// zsh subprocess per keystroke costs several milliseconds of input latency.
+	zdotdirOnce.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "zsh", "-c", "echo $ZDOTDIR")
+		out, err := cmd.Output()
+		if err == nil {
+			zdotdirCached = strings.TrimSpace(string(out))
 		}
-	}
-	
-	home, _ := os.UserHomeDir()
-	return home
+		if zdotdirCached == "" {
+			zdotdirCached, _ = os.UserHomeDir()
+		}
+	})
+
+	return zdotdirCached
 }
+
+var (
+	zdotdirOnce   sync.Once
+	zdotdirCached string
+)
 
 // FishAdapter implementation
 type FishAdapter struct{}
@@ -133,55 +144,316 @@ func GetFishDataDir() string {
 	return filepath.Join(home, ".local", "share", "fish")
 }
 
+// maxSourceDepth caps how deep ScanPosixAliases will follow a chain of
+// `source` lines. Layered dotfiles rarely nest more than two or three levels;
+// the cap is a backstop for pathological configs, since cycles are already
+// handled by the visited set.
+const maxSourceDepth = 8
+
+// aliasScanCache memoizes the last scan. Lookup re-scans aliases on every
+// keystroke, and following `source` chains turns that into a walk over every
+// config file in the tree -- work that is wasted while the files sit unchanged.
+// A stat of each file already visited is enough to tell whether the cached
+// result is still good, and is roughly two orders of magnitude cheaper.
+var aliasScanCache struct {
+	sync.Mutex
+	entryPoints []string
+	stamps      map[string]fileStamp
+	aliases     map[string]string
+}
+
+type fileStamp struct {
+	modTime time.Time
+	size    int64
+}
+
+func statStamp(path string) (fileStamp, bool) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fileStamp{}, false
+	}
+	return fileStamp{modTime: info.ModTime(), size: info.Size()}, true
+}
+
 func ScanPosixAliases(files []string) map[string]string {
-	aliases := make(map[string]string)
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return aliases
+		return map[string]string{}
 	}
 
+	paths := make([]string, 0, len(files))
 	for _, f := range files {
-		path := f
-		if !filepath.IsAbs(f) {
-			path = filepath.Join(home, f)
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
+		if filepath.IsAbs(f) {
+			paths = append(paths, f)
 			continue
 		}
-
-		maps.Copy(aliases, ParseAliases(string(data)))
+		paths = append(paths, filepath.Join(home, f))
 	}
-	return aliases
+
+	aliasScanCache.Lock()
+	defer aliasScanCache.Unlock()
+
+	if cached := cachedAliases(paths); cached != nil {
+		return cached
+	}
+
+	aliases := make(map[string]string)
+	stamps := make(map[string]fileStamp)
+	visited := make(map[string]bool)
+	for _, path := range paths {
+		scanAliasFile(path, aliases, visited, stamps, 0)
+	}
+
+	aliasScanCache.entryPoints = paths
+	aliasScanCache.stamps = stamps
+	aliasScanCache.aliases = aliases
+
+	return maps.Clone(aliases)
+}
+
+// cachedAliases returns the previous scan when the same entry points were asked
+// for and every file it touched is byte-for-byte where it was. A file that has
+// since gone missing counts as a change, so a deleted include invalidates too.
+func cachedAliases(paths []string) map[string]string {
+	if aliasScanCache.aliases == nil || !slices.Equal(aliasScanCache.entryPoints, paths) {
+		return nil
+	}
+	for path, want := range aliasScanCache.stamps {
+		got, ok := statStamp(path)
+		if want == (fileStamp{}) {
+			// Was missing at scan time; it appearing is a change.
+			if ok {
+				return nil
+			}
+			continue
+		}
+		if !ok || got != want {
+			return nil
+		}
+	}
+	return maps.Clone(aliasScanCache.aliases)
+}
+
+// scanAliasFile records the aliases defined in path, following any file it
+// sources. Most real configs keep aliases in a dedicated file pulled in with
+// `source`, so reading only the entry points would miss nearly all of them.
+func scanAliasFile(path string, aliases map[string]string, visited map[string]bool, stamps map[string]fileStamp, depth int) {
+	if depth > maxSourceDepth {
+		return
+	}
+
+	// Key the visited set on the resolved path so a dotfile symlinked into
+	// $HOME isn't scanned twice under both names.
+	key := path
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		key = resolved
+	}
+	if visited[key] {
+		return
+	}
+	visited[key] = true
+
+	// Stamp missing files too, as the zero value: a config that sources a file
+	// which does not exist yet must re-scan once that file appears, and the
+	// parent's own mtime won't change when it does.
+	stamp, _ := statStamp(path)
+	stamps[path] = stamp
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+
+	walkShellConfig(string(data), aliases, func(target string) {
+		scanAliasFile(target, aliases, visited, stamps, depth+1)
+	})
 }
 
 func ParseAliases(data string) map[string]string {
 	aliases := make(map[string]string)
+	walkShellConfig(data, aliases, nil)
+	return aliases
+}
+
+// walkShellConfig reads shell config text top to bottom, recording alias
+// definitions into aliases and handing each `source`/`.` target to onSource (if
+// non-nil) at the point it appears, so a sourced file's definitions land in the
+// same order the shell would apply them.
+func walkShellConfig(data string, aliases map[string]string, onSource func(target string)) {
+	// A config that defines the same alias in both arms of a conditional --
+	// `if which eza; then alias ls='eza'; else alias ls='lsd'; fi` -- would
+	// otherwise end up with the fallback, purely because it is written last.
+	// The condition can't be evaluated from static text, so prefer the first
+	// arm: it is conventionally the preferred tool, with later arms as
+	// fallbacks. altArm tracks whether any enclosing `if` has moved past it.
+	altArm := 0
+	depth := 0
+
 	lines := strings.SplitSeq(data, "\n")
 	for line := range lines {
 		line = strings.TrimSpace(line)
-		if !strings.HasPrefix(line, "alias ") {
-			continue
-		}
-		body := strings.TrimSpace(strings.TrimPrefix(line, "alias"))
-		if body == "" {
+		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
 
-		pairs := SplitAliasTokens(body)
-		for _, pair := range pairs {
-			before, after, ok := strings.Cut(pair, "=")
-			if !ok {
-				continue
-			}
-			key := strings.TrimSpace(before)
-			val := strings.Trim(strings.TrimSpace(after), `"'`)
-			if key != "" && val != "" {
-				aliases[key] = val
+		switch {
+		case line == "if" || strings.HasPrefix(line, "if "):
+			depth++
+		case depth > 0 && (line == "else" || line == "elif" || strings.HasPrefix(line, "elif ")):
+			altArm++
+		case depth > 0 && (line == "fi" || strings.HasPrefix(line, "fi ") || strings.HasPrefix(line, "fi;")):
+			depth--
+			if altArm > 0 {
+				altArm--
 			}
 		}
+
+		if onSource != nil {
+			for _, target := range sourceTargets(line) {
+				onSource(target)
+			}
+		}
+
+		if altArm > 0 {
+			continue
+		}
+		parseAliasLine(line, aliases)
 	}
-	return aliases
+}
+
+func parseAliasLine(line string, aliases map[string]string) {
+	if !strings.HasPrefix(line, "alias ") {
+		return
+	}
+	body := strings.TrimSpace(strings.TrimPrefix(line, "alias"))
+	if body == "" {
+		return
+	}
+
+	pairs := SplitAliasTokens(body)
+	for _, pair := range pairs {
+		before, after, ok := strings.Cut(pair, "=")
+		if !ok {
+			continue
+		}
+		key := strings.TrimSpace(before)
+		val := strings.Trim(strings.TrimSpace(after), `"'`)
+		if key != "" && val != "" {
+			aliases[key] = val
+		}
+	}
+}
+
+// sourceTargets returns the absolute paths a single config line sources. The
+// line is split on shell separators first so guarded forms such as
+// `[ -f "$X" ] && source "$X"` are picked up, not just lines that begin with
+// `source`. Targets that can't be resolved to a literal path -- unset
+// variables, command or process substitution, globs -- are dropped rather than
+// guessed at.
+func sourceTargets(line string) []string {
+	var targets []string
+	for _, segment := range splitShellSegments(line) {
+		segment = strings.TrimSpace(segment)
+
+		var rest string
+		switch {
+		case strings.HasPrefix(segment, "source "):
+			rest = segment[len("source "):]
+		case strings.HasPrefix(segment, ". "):
+			rest = segment[len(". "):]
+		default:
+			continue
+		}
+
+		fields := SplitAliasTokens(strings.TrimSpace(rest))
+		if len(fields) == 0 {
+			continue
+		}
+		if path, ok := expandConfigPath(fields[0]); ok {
+			targets = append(targets, path)
+		}
+	}
+	return targets
+}
+
+// splitShellSegments breaks a line on `&&`, `||` and `;` outside of quotes, so
+// each segment can be tested for a leading command word.
+func splitShellSegments(line string) []string {
+	var segments []string
+	var cur strings.Builder
+	inQuote := false
+	var quoteChar rune
+
+	runes := []rune(line)
+	for i := 0; i < len(runes); i++ {
+		c := runes[i]
+		switch {
+		case !inQuote && (c == '"' || c == '\''):
+			inQuote = true
+			quoteChar = c
+			cur.WriteRune(c)
+		case inQuote && c == quoteChar:
+			inQuote = false
+			cur.WriteRune(c)
+		case !inQuote && c == ';':
+			segments = append(segments, cur.String())
+			cur.Reset()
+		case !inQuote && i+1 < len(runes) && (c == '&' || c == '|') && runes[i+1] == c:
+			segments = append(segments, cur.String())
+			cur.Reset()
+			i++
+		default:
+			cur.WriteRune(c)
+		}
+	}
+	segments = append(segments, cur.String())
+	return segments
+}
+
+// expandConfigPath turns a quoted, variable-bearing path from a config file
+// into an absolute path. It reports false when the path can't be resolved
+// statically, which is the common case for loop variables (`source "$file"`)
+// and process substitution (`source <(fzf --zsh)`).
+func expandConfigPath(raw string) (string, bool) {
+	path := strings.Trim(strings.TrimSpace(raw), `"'`)
+	if path == "" {
+		return "", false
+	}
+	if strings.ContainsAny(path, "*?`") || strings.Contains(path, "$(") || strings.Contains(path, "<(") {
+		return "", false
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", false
+	}
+
+	resolved := true
+	path = os.Expand(path, func(name string) string {
+		if name == "HOME" {
+			return home
+		}
+		val, ok := os.LookupEnv(name)
+		if !ok || val == "" {
+			resolved = false
+			return ""
+		}
+		return val
+	})
+	if !resolved || path == "" {
+		return "", false
+	}
+
+	if path == "~" {
+		path = home
+	} else if strings.HasPrefix(path, "~/") {
+		path = filepath.Join(home, path[2:])
+	}
+
+	if !filepath.IsAbs(path) {
+		return "", false
+	}
+	return filepath.Clean(path), true
 }
 
 func SplitAliasTokens(s string) []string {

--- a/integration/shell/adapter.go
+++ b/integration/shell/adapter.go
@@ -337,7 +337,7 @@ func parseAliasLine(line string, aliases map[string]string) {
 			continue
 		}
 		key := strings.TrimSpace(before)
-		val := strings.Trim(strings.TrimSpace(after), `"'`)
+		val := unquoteAliasValue(strings.TrimSpace(after))
 		if key != "" && val != "" {
 			aliases[key] = val
 		}
@@ -454,6 +454,27 @@ func expandConfigPath(raw string) (string, bool) {
 		return "", false
 	}
 	return filepath.Clean(path), true
+}
+
+// unquoteAliasValue removes one matched pair of surrounding quotes.
+//
+// strings.Trim takes a cutset and strips greedily from both ends, so a value
+// whose last character is itself a quote lost it:
+//
+//	alias gwip="git add --all && git commit -am 'WIP'"
+//	  -> git add --all && git commit -am 'WIP
+//
+// That is not only a wrong description in the menu. With core.expand-alias on,
+// the target is typed back into the prompt when the alias is expanded, so the
+// user was left holding a command line with an unbalanced quote.
+func unquoteAliasValue(s string) string {
+	if len(s) < 2 {
+		return s
+	}
+	if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+		return s[1 : len(s)-1]
+	}
+	return s
 }
 
 func SplitAliasTokens(s string) []string {

--- a/integration/shell/adapter_test.go
+++ b/integration/shell/adapter_test.go
@@ -179,3 +179,25 @@ func TestScanPosixAliasesHandlesSourceCycle(t *testing.T) {
 		t.Errorf("ScanPosixAliases() = %v; want %v", got, expected)
 	}
 }
+func TestParseAliasesKeepsNestedQuotes(t *testing.T) {
+	// strings.Trim with a cutset strips greedily, so a value ending in a quote
+	// lost it. With core.expand-alias on the target is typed back into the
+	// prompt, so this left an unbalanced quote on the command line.
+	input := `
+alias gwip="git add --all && git commit -am 'WIP'"
+alias shrug="echo '¯\_(ツ)_/¯' | pbcopy"
+alias plain=mcd
+alias spaced='git status -sb'
+`
+	expected := map[string]string{
+		"gwip":   "git add --all && git commit -am 'WIP'",
+		"shrug":  `echo '¯\_(ツ)_/¯' | pbcopy`,
+		"plain":  "mcd",
+		"spaced": "git status -sb",
+	}
+
+	got := ParseAliases(input)
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("ParseAliases() = %#v; want %#v", got, expected)
+	}
+}

--- a/integration/shell/adapter_test.go
+++ b/integration/shell/adapter_test.go
@@ -1,8 +1,11 @@
 package shell
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestScanPosixAliases(t *testing.T) {
@@ -46,5 +49,133 @@ func TestSplitAliasTokens(t *testing.T) {
 				t.Errorf("SplitAliasTokens(%q) = %v; want %v", tt.input, got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestParseAliasesPrefersFirstConditionalArm(t *testing.T) {
+	// A dotfile that picks a tool with a fallback defines the same alias twice.
+	// The first arm is the preferred one; letting the fallback win just because
+	// it is written last points suggestions at the wrong command.
+	input := `
+if which eza &>/dev/null; then
+  alias ls='eza --icons'
+  alias lt='eza -T'
+else
+  alias ls='lsd'
+  alias lt='lsd --tree'
+fi
+alias g='git'
+`
+	expected := map[string]string{
+		"ls": "eza --icons",
+		"lt": "eza -T",
+		"g":  "git",
+	}
+
+	got := ParseAliases(input)
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("ParseAliases() = %v; want %v", got, expected)
+	}
+}
+
+func TestScanPosixAliasesFollowsSource(t *testing.T) {
+	dir := t.TempDir()
+
+	aliasFile := filepath.Join(dir, "aliases.zsh")
+	if err := os.WriteFile(aliasFile, []byte("alias gst='git status'\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	nestedFile := filepath.Join(dir, "nested.zsh")
+	if err := os.WriteFile(nestedFile, []byte("alias k='kubectl'\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// The guarded form and the `.` spelling both appear in real configs, as does
+	// a source line that can't be resolved statically -- that one must be
+	// skipped rather than guessed at.
+	rc := filepath.Join(dir, ".zshrc")
+	content := "alias v='nvim'\n" +
+		"source \"$IRIS_TEST_DIR/aliases.zsh\"\n" +
+		"[ -f \"" + nestedFile + "\" ] && . \"" + nestedFile + "\"\n" +
+		"for f in $dir/*.zsh; do source \"$f\"; done\n" +
+		"source <(fzf --zsh)\n"
+	if err := os.WriteFile(rc, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("IRIS_TEST_DIR", dir)
+
+	got := ScanPosixAliases([]string{rc})
+	expected := map[string]string{
+		"v":   "nvim",
+		"gst": "git status",
+		"k":   "kubectl",
+	}
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("ScanPosixAliases() = %v; want %v", got, expected)
+	}
+}
+
+func TestScanPosixAliasesCacheInvalidation(t *testing.T) {
+	dir := t.TempDir()
+	rc := filepath.Join(dir, ".zshrc")
+	sourced := filepath.Join(dir, "aliases.zsh")
+
+	if err := os.WriteFile(rc, []byte("source \""+sourced+"\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// The sourced file does not exist yet. Its later appearance has to
+	// invalidate the cache even though the file that sources it never changes.
+	if got := ScanPosixAliases([]string{rc}); len(got) != 0 {
+		t.Fatalf("ScanPosixAliases() = %v; want empty", got)
+	}
+
+	if err := os.WriteFile(sourced, []byte("alias gst='git status'\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := ScanPosixAliases([]string{rc})
+	if !reflect.DeepEqual(got, map[string]string{"gst": "git status"}) {
+		t.Fatalf("after create: ScanPosixAliases() = %v; want gst", got)
+	}
+
+	// Editing a sourced file must be picked up as well. Size differs here, but
+	// keep the mtime bump explicit so the check doesn't rest on that alone.
+	if err := os.WriteFile(sourced, []byte("alias gst='git status -sb'\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(sourced, time.Now().Add(time.Second), time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	got = ScanPosixAliases([]string{rc})
+	if !reflect.DeepEqual(got, map[string]string{"gst": "git status -sb"}) {
+		t.Fatalf("after edit: ScanPosixAliases() = %v; want updated gst", got)
+	}
+
+	// A cached result must not be shared by reference; a caller mutating it
+	// would otherwise poison every later scan.
+	got["injected"] = "nope"
+	if again := ScanPosixAliases([]string{rc}); len(again) != 1 {
+		t.Fatalf("cache returned a mutable reference: %v", again)
+	}
+}
+
+func TestScanPosixAliasesHandlesSourceCycle(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.zsh")
+	b := filepath.Join(dir, "b.zsh")
+
+	if err := os.WriteFile(a, []byte("alias a='echo a'\nsource \""+b+"\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(b, []byte("alias b='echo b'\nsource \""+a+"\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := ScanPosixAliases([]string{a})
+	expected := map[string]string{"a": "echo a", "b": "echo b"}
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("ScanPosixAliases() = %v; want %v", got, expected)
 	}
 }


### PR DESCRIPTION
## Problem

`ScanPosixAliases` reads only the shell's entry-point files — `~/.zshenv`, `~/.zprofile`, `~/.zshrc` for zsh — and greps them for literal `alias` lines. It never follows `source`.

That is the layout almost every dotfile set outgrows. Once you have more than a handful of aliases they move into their own file, and `.zshrc` just does:

```zsh
source "$DOTFILES/zsh/aliases.zsh"
```

From that point iris sees **zero** aliases. On the config I hit this with, 142 aliases were invisible — no alias ever appeared in the top-level menu, and `spec.Lookup` never expanded one, so an aliased `ls` or `v` resolved to nothing.

## Changes

### 1. Follow `source` / `.` targets (`integration/shell/adapter.go`)

Recursive, with the conservative bits spelled out:

- `~` and `$VAR` / `${VAR}` are expanded from the environment.
- Targets that **cannot** be resolved statically are skipped rather than guessed at — loop variables (`for f in ...; do source "$f"; done`), command and process substitution (`source <(fzf --zsh)`), globs.
- Lines are split on `&&`, `||` and `;` outside quotes first, so guarded forms like `[ -f "$X" ] && source "$X"` are picked up, not just lines beginning with `source`.
- A visited set keyed on the symlink-resolved path handles cycles and dotfiles symlinked into `$HOME` under two names; `maxSourceDepth` caps pathological nesting.

### 2. Prefer the first arm of a conditional

A config that picks a tool with a fallback defines the same alias twice:

```zsh
if which eza &>/dev/null; then
  alias ls='eza --icons --classify'
else
  alias ls='lsd'
fi
```

Previously the fallback won, purely because it is written last — pointing suggestions at a tool the user isn't running. The condition can't be evaluated from static text, so this prefers the first arm, which is conventionally the preferred tool with later arms as fallbacks.

### 3. Cache the scan

`Lookup` calls `ScanAliases()` on **every keystroke**. Following `source` would have turned that into a walk of the entire config tree per keypress, so the result is memoized against the mtime and size of every file visited. Missing files are stamped too, so a sourced file that appears later still invalidates.

While measuring this I found `GetZshConfigDir` was spawning a `zsh -c 'echo $ZDOTDIR'` subprocess on every keystroke whenever `ZDOTDIR` is unset — that alone was the bulk of the existing cost. It is now resolved once per process; `ZDOTDIR` cannot change under a running iris.

On a real config (9 files, 142 aliases, Apple M5 Pro):

| | ns/op |
|---|---|
| before (3 files, no `source`) | 3,368,611 |
| after (full tree, cached) | 17,163 |

~200× faster while reading substantially more.

### 4. Path generators for fs commands missing them

`eza`, `exa`, `lsd`, `trash` → `FileGenerator()`; `tree`, `mkdir`, `rmdir`, `dust`, `broot` → `FileGenerator("/")`.

These had options but no generator, so they offered flags and nothing else once you typed a path. It matters more once #1 works: `Lookup` expands `ls` to its target before resolving a spec, so where `ls` is aliased to `eza`, the built-in `ls` spec (which does have a `FileGenerator`) is never reached and path suggestions vanish.

## Tests

Four new tests in `integration/shell/adapter_test.go`:

- `TestScanPosixAliasesFollowsSource` — the `source` and `.` spellings, the guarded `[ -f X ] && . X` form, and that unresolvable targets are skipped.
- `TestParseAliasesPrefersFirstConditionalArm`
- `TestScanPosixAliasesCacheInvalidation` — appearance of a not-yet-existing sourced file, edits to a sourced file, and that the cache doesn't hand out a mutable reference.
- `TestScanPosixAliasesHandlesSourceCycle`

`go test -race ./...` passes. (`TestGitSuggestions` fails in my environment only because my git signs commits through an agent the test sandbox can't reach; it passes with `GIT_CONFIG_GLOBAL=/dev/null`.)

Verified end to end against the real config that prompted this: 126 aliases discovered (the remainder are genuine duplicate definitions and the skipped fallback arm), `ls` correctly resolving to `eza --icons --classify` rather than the `lsd` fallback.

No new dependencies. Existing `ParseAliases` and `SplitAliasTokens` signatures are unchanged.

## Note

`gofmt` reports pre-existing trailing whitespace in `adapter.go` (in `ScanAliases` and `GetZshConfigDir`, untouched lines). I left it alone to keep the diff focused — happy to include the formatting fix if you'd prefer.
