### PR TITLE
fix(spec): isolate __complete probe from the controlling terminal

### DIFF
--- a/spec/cobra_complete.go
+++ b/spec/cobra_complete.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -90,6 +91,16 @@ func buildCobraCacheKey(binKey string, args []string, partial string) string {
 	return sb.String()
 }
 
+// newProbeCmd builds and isolates the `__complete` probe command.
+// starts the child in its own session so it has no controlling terminal
+// and therefore won't affect the user's tty in the case of programs that
+// don't respect `__complete`.
+func newProbeCmd(ctx context.Context, binName string, args []string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, binName, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	return cmd
+}
+
 // QueryCobraComplete calls `binName __complete <args> <partial>` and returns
 // structured suggestions cached per binary mtime, args, and partial.
 // returns nil if the binary is not Cobra-based or times out.
@@ -113,7 +124,8 @@ func QueryCobraComplete(binName string, args []string, partial string) []Suggest
 
 	cmdArgs := append([]string{"__complete"}, args...)
 	cmdArgs = append(cmdArgs, partial)
-	out, err := exec.CommandContext(ctx, binName, cmdArgs...).Output()
+	probe := newProbeCmd(ctx, binName, cmdArgs)
+	out, err := probe.Output()
 	if err != nil {
 		return nil
 	}

--- a/spec/cobra_complete_test.go
+++ b/spec/cobra_complete_test.go
@@ -2,7 +2,9 @@ package spec
 
 import (
 	"context"
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -147,13 +149,7 @@ func TestNewProbeCmd_Setsid(t *testing.T) {
 // if newProbeCmd actually denies it access to tty
 func TestNewProbeCmd_NoControllingTerminal(t *testing.T) {
 	dir := t.TempDir()
-	resultPath := filepath.Join(dir, "result")
-	script := "#!/bin/sh\n" +
-		"if exec 3<>/dev/tty 2>/dev/null; then\n" +
-		"  echo opened > " + resultPath + "\n" +
-		"else\n" +
-		"  echo denied > " + resultPath + "\n" +
-		"fi\n"
+	script := "#!/bin/sh\nexec 3<>/dev/tty"
 
 	binPath := filepath.Join(dir, "ttyprobe")
 	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
@@ -162,14 +158,11 @@ func TestNewProbeCmd_NoControllingTerminal(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	_ = newProbeCmd(ctx, binPath, nil).Run()
+	runErr := newProbeCmd(ctx, binPath, nil).Run()
 
-	out, err := os.ReadFile(resultPath)
-	if err != nil {
-		t.Fatalf("probe script did not run: %v", err)
-	}
-	if got := string(out); got != "denied\n" {
-		t.Errorf("expected probe to be denied a controlling terminal, got %q", got)
+	var exitErr *exec.ExitError
+	if !errors.As(runErr, &exitErr) {
+		t.Fatalf("expected probe script to exit nonzero after failing to open /dev/tty, got %v", runErr)
 	}
 }
 

--- a/spec/cobra_complete_test.go
+++ b/spec/cobra_complete_test.go
@@ -1,7 +1,11 @@
 package spec
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestParseCobraOutput_ValidCobra(t *testing.T) {
@@ -128,6 +132,44 @@ func TestLookup_CobraKubectl(t *testing.T) {
 			break
 		}
 		t.Logf("  - Cmd: %-30s | Source: %-15s | Priority: %d | Desc: %s", r.Cmd, r.Source, r.Priority, r.Desc)
+	}
+}
+
+func TestNewProbeCmd_Setsid(t *testing.T) {
+	cmd := newProbeCmd(context.Background(), "true", nil)
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setsid {
+		t.Fatalf("expected probe command to set Setsid: true, got %+v", cmd.SysProcAttr)
+	}
+}
+
+// TestNewProbeCmd_NoControllingTerminal writes a small script
+// and runs it to check
+// if newProbeCmd actually denies it access to tty
+func TestNewProbeCmd_NoControllingTerminal(t *testing.T) {
+	dir := t.TempDir()
+	resultPath := filepath.Join(dir, "result")
+	script := "#!/bin/sh\n" +
+		"if exec 3<>/dev/tty 2>/dev/null; then\n" +
+		"  echo opened > " + resultPath + "\n" +
+		"else\n" +
+		"  echo denied > " + resultPath + "\n" +
+		"fi\n"
+
+	binPath := filepath.Join(dir, "ttyprobe")
+	if err := os.WriteFile(binPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("failed to write probe script: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = newProbeCmd(ctx, binPath, nil).Run()
+
+	out, err := os.ReadFile(resultPath)
+	if err != nil {
+		t.Fatalf("probe script did not run: %v", err)
+	}
+	if got := string(out); got != "denied\n" {
+		t.Errorf("expected probe to be denied a controlling terminal, got %q", got)
 	}
 }
 


### PR DESCRIPTION
run the `__complete` probe subprocess in its own session so that a cobra-incompatible binary that ignores `__complete` can't mess with the user's controlling terminal.
tested on both macos and nixos.
encountered the problem while trying to use [visidata](https://www.visidata.org/).