### PR TITLE
feat(config): ghost-text as a 3-mode option, decoupled from the menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ cobra-probe-enabled = true     # fall back to probing cobra binaries for complet
 
 [ui]
 style = "modern"       # "modern" or "classic"
-ghost-text = true      # faded inline preview of top suggestion
+ghost-text = 1         # 0 = off, 1 = menu + ghost text, 2 = ghost text only
 hidden-files = false   # include dotfiles in suggestions
 max-suggestions = 100  # max suggestions ranked before display
 max-height = 15        # max visible rows in the menu

--- a/README.md
+++ b/README.md
@@ -351,6 +351,9 @@ timeout_ms = 5000  # ms before giving up
 > [!NOTE]
 > Using `api_key_env` is recommended over hardcoding `api_key` in plain text to keep credentials out of configuration files.
 
+> [!NOTE]
+> `ghost-text` used to be a boolean. Existing configs keep working: `true` is read as `1` and `false` as `0`, so there is nothing to change on upgrade.
+
 
 ## Default shortcuts
 

--- a/integration/overlay.go
+++ b/integration/overlay.go
@@ -186,6 +186,12 @@ func (o *Overlay) GetTypedQuery() string {
 	return o.TypedQuery
 }
 
+func (o *Overlay) SetTypedQuery(q string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.TypedQuery = q
+}
+
 func (o *Overlay) GetCurrentCmd() string {
 	o.mu.Lock()
 	defer o.mu.Unlock()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,31 @@ import (
 
 type Duration time.Duration
 
+// ghost-text was a bool before it grew a third mode, so old configs must keep loading
+type GhostTextMode int
+
+func (g *GhostTextMode) UnmarshalTOML(val any) error {
+	switch v := val.(type) {
+	case bool:
+		if v {
+			*g = GhostTextOn
+		} else {
+			*g = GhostTextOff
+		}
+	case int64:
+		*g = GhostTextMode(v)
+	default:
+		return fmt.Errorf("ghost-text must be a boolean or integer")
+	}
+	return nil
+}
+
+const (
+	GhostTextOff GhostTextMode = iota
+	GhostTextOn
+	GhostTextIndividual
+)
+
 var (
 	_ encoding.TextUnmarshaler = (*Duration)(nil)
 	_ encoding.TextMarshaler   = (*Duration)(nil)
@@ -47,13 +72,13 @@ type CoreConfig struct {
 }
 
 type UIConfig struct {
-	Style           string `toml:"style"`
-	GhostText       bool   `toml:"ghost-text"`
-	ShowHiddenFiles bool   `toml:"hidden-files"`
-	MaxSuggestions  int    `toml:"max-suggestions"`
-	MaxHeight       int    `toml:"max-height"`
-	MaxWidth        int    `toml:"max-width"`
-	NerdFonts       bool   `toml:"nerd-fonts"`
+	Style           string        `toml:"style"`
+	GhostText       GhostTextMode `toml:"ghost-text"`
+	ShowHiddenFiles bool          `toml:"hidden-files"`
+	MaxSuggestions  int           `toml:"max-suggestions"`
+	MaxHeight       int           `toml:"max-height"`
+	MaxWidth        int           `toml:"max-width"`
+	NerdFonts       bool          `toml:"nerd-fonts"`
 }
 
 type GitConfig struct {
@@ -289,6 +314,10 @@ func validate(cfg *Config) error {
 
 	if cfg.Updater.AutoUpdate < 0 || cfg.Updater.AutoUpdate > 2 {
 		return fmt.Errorf("updater.auto-update: invalid value %d (want: 0=off, 1=auto, 2=confirm)", cfg.Updater.AutoUpdate)
+	}
+
+	if cfg.UI.GhostText < GhostTextOff || cfg.UI.GhostText > GhostTextIndividual {
+		return fmt.Errorf("ui.ghost-text: invalid value %d (want: 0=off, 1=on, 2=individual)", cfg.UI.GhostText)
 	}
 
 	if cfg.UI.MaxSuggestions < 1 || cfg.UI.MaxSuggestions > 500 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/BurntSushi/toml"
 )
 
 func TestDefaultConfigAndState(t *testing.T) {
@@ -130,7 +132,7 @@ model = "qwen-2.5-coder-32b"
 	t.Setenv("IRIS_CORE_DEBUG", "true")
 	t.Setenv("IRIS_CORE_SHELL", "fish")
 	t.Setenv("IRIS_CORE_MODE", "history")
-	t.Setenv("IRIS_UI_GHOST_TEXT", "false")
+	t.Setenv("IRIS_UI_GHOST_TEXT", "0")
 	t.Setenv("IRIS_UI_MAX_SUGGESTIONS", "250")
 	t.Setenv("IRIS_UI_MAX_HEIGHT", "25")
 	t.Setenv("IRIS_UPDATER_CHANNEL", "nightly")
@@ -156,8 +158,8 @@ model = "qwen-2.5-coder-32b"
 	if cfg.Core.Mode != "history" {
 		t.Errorf("expected mode history, got %q", cfg.Core.Mode)
 	}
-	if cfg.UI.GhostText {
-		t.Errorf("expected ghost text to be false")
+	if cfg.UI.GhostText != GhostTextOff {
+		t.Errorf("expected ghost text off, got %d", cfg.UI.GhostText)
 	}
 	if cfg.UI.MaxSuggestions != 250 {
 		t.Errorf("expected max suggestions 250, got %d", cfg.UI.MaxSuggestions)
@@ -365,5 +367,72 @@ func TestMatchKey_NavKeybindingsNoLongerHijackEnter(t *testing.T) {
 		if m, _ := MatchKey([]byte{0x0d}, expected); m {
 			t.Errorf("MatchKey(enter{0x0d}, %q) matched; Enter must remain reserved", expected)
 		}
+	}
+}
+
+func TestGhostTextModeUnmarshalTOML(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  GhostTextMode
+	}{
+		{"legacy true", "ghost-text = true", GhostTextOn},
+		{"legacy false", "ghost-text = false", GhostTextOff},
+		{"off", "ghost-text = 0", GhostTextOff},
+		{"on", "ghost-text = 1", GhostTextOn},
+		{"individual", "ghost-text = 2", GhostTextIndividual},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var cfg Config
+			if _, err := toml.Decode("[ui]\n"+tc.input+"\n", &cfg); err != nil {
+				t.Fatalf("decode %q: %v", tc.input, err)
+			}
+			if cfg.UI.GhostText != tc.want {
+				t.Errorf("%q: got %d, want %d", tc.input, cfg.UI.GhostText, tc.want)
+			}
+		})
+	}
+
+	var cfg Config
+	if _, err := toml.Decode("[ui]\nghost-text = \"yes\"\n", &cfg); err == nil {
+		t.Error("expected a string ghost-text to be rejected")
+	}
+}
+
+func TestValidateGhostTextRange(t *testing.T) {
+	cfg := DefaultConfig()
+
+	for _, valid := range []GhostTextMode{GhostTextOff, GhostTextOn, GhostTextIndividual} {
+		cfg.UI.GhostText = valid
+		if err := validate(cfg); err != nil {
+			t.Errorf("expected ghost-text=%d to be valid, got error: %v", valid, err)
+		}
+	}
+
+	for _, invalid := range []GhostTextMode{-1, 3} {
+		cfg.UI.GhostText = invalid
+		if err := validate(cfg); err == nil {
+			t.Errorf("expected ghost-text=%d to be rejected", invalid)
+		}
+	}
+}
+
+func TestGhostTextEnvAcceptsBoolAndInt(t *testing.T) {
+	cases := map[string]GhostTextMode{
+		"0": GhostTextOff, "1": GhostTextOn, "2": GhostTextIndividual,
+		"true": GhostTextOn, "false": GhostTextOff,
+	}
+
+	for val, want := range cases {
+		t.Run(val, func(t *testing.T) {
+			t.Setenv("IRIS_UI_GHOST_TEXT", val)
+			cfg := DefaultConfig()
+			applyEnv(cfg)
+			if cfg.UI.GhostText != want {
+				t.Errorf("IRIS_UI_GHOST_TEXT=%q: got %d, want %d", val, cfg.UI.GhostText, want)
+			}
+		})
 	}
 }

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -18,7 +18,7 @@ func DefaultConfig() *Config {
 		},
 		UI: UIConfig{
 			Style:           "modern",
-			GhostText:       true,
+			GhostText:       GhostTextOn,
 			ShowHiddenFiles: false,
 			MaxSuggestions:  100,
 			MaxHeight:       15,

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -19,8 +19,14 @@ func applyEnv(cfg *Config) {
 		cfg.Core.Mode = val
 	}
 	if val := os.Getenv("IRIS_UI_GHOST_TEXT"); val != "" {
-		if b, err := strconv.ParseBool(val); err == nil {
-			cfg.UI.GhostText = b
+		if i, err := strconv.Atoi(val); err == nil {
+			cfg.UI.GhostText = GhostTextMode(i)
+		} else if b, err := strconv.ParseBool(val); err == nil {
+			if b {
+				cfg.UI.GhostText = GhostTextOn
+			} else {
+				cfg.UI.GhostText = GhostTextOff
+			}
 		}
 	}
 	if val := os.Getenv("IRIS_UI_MAX_SUGGESTIONS"); val != "" {

--- a/root/config_cmd.go
+++ b/root/config_cmd.go
@@ -78,8 +78,9 @@ nerd-fonts = true
 # show hidden files with dot prefix
 hidden-files = false
 
-# enable inline ghost text
-ghost-text = true
+# 0 = off, 1 = on, 2 = ghost text only (menu opens on toggle key)
+# legacy true/false still accepted
+ghost-text = 1
 
 # maximum suggestions to display
 max-suggestions = 100

--- a/root/init.go
+++ b/root/init.go
@@ -98,6 +98,12 @@ fi
 
 `)
 		case "fish":
+			// fish's own autosuggestions collide with iris ghost text, but only
+			// turn them off when ghost text is actually on
+			disableFishAutosuggest := ""
+			if config.Get().UI.GhostText != config.GhostTextOff {
+				disableFishAutosuggest = "    set -g fish_autosuggestion_enabled 0\n"
+			}
 			fmt.Printf(`
 # Iris Autostart Hook
 # a multiplexer pane inherits IRIS_* but runs on its own tty, so those vars
@@ -120,7 +126,7 @@ end
 
 # Iris Autocomplete Hook
 if set -q IRIS_PID; and set -q IRIS_FD
-    function _iris_fish_postexec --on-event fish_postexec
+%s    function _iris_fish_postexec --on-event fish_postexec
         set -l iris_exit_code $status
         printf "IRIS_CWD:%%s\x00" "$PWD" >&$IRIS_FD 2>/dev/null
         printf "IRIS_CMD_STOP:%%s\x00" "$iris_exit_code" >&$IRIS_FD 2>/dev/null
@@ -132,7 +138,7 @@ if set -q IRIS_PID; and set -q IRIS_FD
         printf "IRIS_CMD_START\x00" >&$IRIS_FD 2>/dev/null
     end
 end
-`)
+`, disableFishAutosuggest)
 		}
 	},
 }
@@ -257,8 +263,9 @@ nerd-fonts = true
 # show hidden files with dot prefix
 hidden-files = false
 
-# enable inline ghost text
-ghost-text = true
+# 0 = off, 1 = on, 2 = ghost text only (menu opens on toggle key)
+# legacy true/false still accepted
+ghost-text = 1
 
 # maximum suggestions to display
 max-suggestions = 100

--- a/root/init_test.go
+++ b/root/init_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/versenilvis/iris/internal/config"
 )
 
 func captureInitScript(t *testing.T, shell string) string {
@@ -55,5 +57,29 @@ func TestInitAutostartRequiresInteractiveShell(t *testing.T) {
 				t.Fatalf("%s autostart is not guarded by %q:\n%s", shell, guard, head[cond:])
 			}
 		})
+	}
+}
+
+func TestFishAutosuggestionsFollowGhostTextMode(t *testing.T) {
+	const marker = "set -g fish_autosuggestion_enabled 0"
+
+	cases := []struct {
+		mode config.GhostTextMode
+		want bool
+	}{
+		{config.GhostTextOff, false},
+		{config.GhostTextOn, true},
+		{config.GhostTextIndividual, true},
+	}
+
+	for _, tc := range cases {
+		cfg := config.DefaultConfig()
+		cfg.UI.GhostText = tc.mode
+		config.Init(cfg)
+
+		script := captureInitScript(t, "fish")
+		if got := strings.Contains(script, marker); got != tc.want {
+			t.Errorf("ghost-text=%d: fish autosuggestions disabled=%v, want %v", tc.mode, got, tc.want)
+		}
 	}
 }

--- a/root/wrapper.go
+++ b/root/wrapper.go
@@ -150,6 +150,12 @@ func nullTokenSplit(data []byte, atEOF bool) (advance int, token []byte, err err
 	return 0, nil, nil
 }
 
+// In ghost-text mode 2 the menu toggle hides the menu box only: ghost text
+// outlives it, so rendering must keep going with the menu off.
+func menuOnlyHidden(mode config.GhostTextMode, menuEnabled bool) bool {
+	return !menuEnabled && mode == config.GhostTextIndividual
+}
+
 // runWrapper sets up the pty environment, launches the shell,
 // and manages the main input loop to provide real-time suggestions
 // it handles raw terminal mode to intercept keystrokes and
@@ -343,11 +349,11 @@ func runWrapper() {
 	var isCommandActive atomic.Bool
 	var isAltScreenActive atomic.Bool
 	var disableGhostText atomic.Bool
-	disableGhostText.Store(!config.Get().UI.GhostText)
+	disableGhostText.Store(config.Get().UI.GhostText == config.GhostTextOff)
 	var renderOverlayFn atomic.Value // holds func()
 	renderOverlayFn.Store(func() {})
 	config.AutoDetectConfigChange(func(cfg *config.Config) {
-		disableGhostText.Store(!cfg.UI.GhostText)
+		disableGhostText.Store(cfg.UI.GhostText == config.GhostTextOff)
 		if renderer, ok := renderOverlayFn.Load().(func()); ok {
 			renderer()
 		}
@@ -379,7 +385,7 @@ func runWrapper() {
 		return pgrp != shellPGID
 	}
 
-	suggestionsEnabled := true
+	suggestionsEnabled := config.Get().UI.GhostText != config.GhostTextIndividual
 
 	// Shared handler for configured navigation keys (e.g. ctrl+j / ctrl+k).
 	// Moves the overlay cursor when visible, otherwise opens history/spec
@@ -777,7 +783,13 @@ func runWrapper() {
 		}
 		currentCmd := overlay.GetCurrentCmd()
 		logger.Debugf("RenderOverlay nav: %v, typedQuery: '%s', currentCmd: '%s'", navCopy, overlay.GetTypedQuery(), currentCmd)
-		b.WriteString(overlay.Render())
+		if menuOnlyHidden(config.Get().UI.GhostText, suggestionsEnabled) {
+			// Clear() erases the drawn box without dropping item state, so the
+			// ghost text written above still has a suggestion behind it
+			b.WriteString(overlay.Clear())
+		} else {
+			b.WriteString(overlay.Render())
+		}
 		writeStdout([]byte(b.String()))
 	}
 
@@ -785,7 +797,7 @@ func runWrapper() {
 		renderMu.Lock()
 		defer renderMu.Unlock()
 
-		if !suggestionsEnabled || isExecuting() {
+		if isExecuting() || (!suggestionsEnabled && !menuOnlyHidden(config.Get().UI.GhostText, suggestionsEnabled)) {
 			if renderTimer != nil {
 				renderTimer.Stop()
 				renderTimer = nil
@@ -846,9 +858,16 @@ func runWrapper() {
 					intercepted = true
 					suggestionsEnabled = !suggestionsEnabled
 					if !suggestionsEnabled {
-						writeStdout([]byte(overlay.ClearAndDisable()))
+						if menuOnlyHidden(config.Get().UI.GhostText, suggestionsEnabled) {
+							writeStdout([]byte(overlay.Clear()))
+						} else {
+							writeStdout([]byte(overlay.ClearAndDisable()))
+						}
 					} else {
 						shouldOverlayDraw = true
+					}
+					if renderer, ok := renderOverlayFn.Load().(func()); ok {
+						renderer()
 					}
 					i += consumed - 1
 					continue
@@ -975,7 +994,7 @@ func runWrapper() {
 					if strings.TrimSpace(cmdToSubmit) == "iris reload" {
 						if newCfg, err := config.Load(); err == nil {
 							config.Init(newCfg)
-							disableGhostText.Store(!newCfg.UI.GhostText)
+							disableGhostText.Store(newCfg.UI.GhostText == config.GhostTextOff)
 						}
 						msg := "echo -e '\\033[32m✓ Iris configuration reloaded successfully.\\033[0m'\r"
 						_, _ = ptmx.Write(append([]byte{0x15}, []byte(msg)...))
@@ -986,7 +1005,7 @@ func runWrapper() {
 						activeModeMu.Lock()
 						activeMode = loadMode()
 						activeModeMu.Unlock()
-						disableGhostText.Store(false)
+						disableGhostText.Store(config.Get().UI.GhostText == config.GhostTextOff)
 						shouldOverlayDraw = false
 						userNavigated.Store(false)
 						continue
@@ -1003,7 +1022,7 @@ func runWrapper() {
 					activeModeMu.Unlock()
 					isCommandActive.Store(true)
 					_, _ = ptmx.Write([]byte{b}) // forward enter to terminal
-					disableGhostText.Store(false)
+					disableGhostText.Store(config.Get().UI.GhostText == config.GhostTextOff)
 					shouldOverlayDraw = false
 					userNavigated.Store(false)
 					continue
@@ -1173,7 +1192,7 @@ func runWrapper() {
 					activeModeMu.Lock()
 					activeMode = loadMode()
 					activeModeMu.Unlock()
-					disableGhostText.Store(false)
+					disableGhostText.Store(config.Get().UI.GhostText == config.GhostTextOff)
 					shouldOverlayDraw = false
 					userNavigated.Store(false)
 					continue

--- a/root/wrapper.go
+++ b/root/wrapper.go
@@ -422,6 +422,10 @@ func runWrapper() {
 				_, _ = ptmx.Write(toWrite)
 			}
 
+			// ghost text is derived from TypedQuery, so history navigation that
+			// rewrites the buffer must move it too or the hint lags a selection
+			overlay.SetTypedQuery(bufCopy)
+
 			var b strings.Builder
 			if !disableGhostText.Load() {
 				b.WriteString(overlay.RenderGhostText(bufCopy, true, offsetCopy == 0))
@@ -688,6 +692,13 @@ func runWrapper() {
 		offsetCopy := cursorOffset
 		bufferMu.Unlock()
 
+		// Esc and unhandled keys disable ghost text only until the next key.
+		// Letting that outlive this render means RenderGhostText never runs to
+		// erase the glyphs already on the line, so they smear as the user edits.
+		if config.Get().UI.GhostText != config.GhostTextOff {
+			disableGhostText.Store(false)
+		}
+
 		activeModeMu.RLock()
 		modeCopy := activeMode
 		activeModeMu.RUnlock()
@@ -695,6 +706,10 @@ func runWrapper() {
 		navCopy := userNavigated.Load()
 
 		runes := []rune(bufCopy)
+		// with the cursor mid-line, rank against the whole command but render
+		// against the prefix: searching the prefix alone re-ranks on every
+		// keystroke and makes the ghost text flip around behind the cursor
+		queryForSearch := bufCopy
 		if offsetCopy > 0 && offsetCopy <= len(runes) {
 			bufCopy = string(runes[:len(runes)-offsetCopy])
 		}
@@ -757,8 +772,8 @@ func runWrapper() {
 				writeStdout([]byte(overlay.ClearAndDisable()))
 				return
 			}
-			logger.Debugf("Render query: '%s', mode: %s", bufCopy, modeCopy)
-			results := MergeResults(bufCopy, modeCopy)
+			logger.Debugf("Render query: '%s', mode: %s", queryForSearch, modeCopy)
+			results := MergeResults(queryForSearch, modeCopy)
 			logger.Debugf("Render results found: %d", len(results))
 
 			if len(results) == 0 || (len(results) == 1 && strings.TrimSpace(results[0].Cmd) == strings.TrimSpace(bufCopy) && !strings.HasSuffix(bufCopy, " ")) {

--- a/root/wrapper_test.go
+++ b/root/wrapper_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"golang.org/x/term"
+
+	"github.com/versenilvis/iris/internal/config"
 )
 
 func wantDir(t *testing.T, path string) string {
@@ -130,6 +132,28 @@ func TestNullTokenSplit(t *testing.T) {
 			}
 			if string(token) != tt.wantToken {
 				t.Errorf("token = %q, want %q", token, tt.wantToken)
+			}
+		})
+	}
+}
+
+func TestMenuOnlyHidden(t *testing.T) {
+	tests := []struct {
+		name        string
+		mode        config.GhostTextMode
+		menuEnabled bool
+		want        bool
+	}{
+		{"mode 2, menu toggled off", config.GhostTextIndividual, false, true},
+		{"mode 2, menu on", config.GhostTextIndividual, true, false},
+		{"mode 1, menu toggled off", config.GhostTextOn, false, false},
+		{"mode 1, menu on", config.GhostTextOn, true, false},
+		{"mode 0, menu toggled off", config.GhostTextOff, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := menuOnlyHidden(tt.mode, tt.menuEnabled); got != tt.want {
+				t.Errorf("menuOnlyHidden(%d, %v) = %v, want %v", tt.mode, tt.menuEnabled, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Turns `ghost-text` into a 3-mode option and decouples ghost text from the suggestion menu.

Closes #102, closes #140.

### `ghost-text` modes

| Value | Behavior |
| :---- | :------- |
| `0`   | Off |
| `1`   | Menu and ghost text together (default) |
| `2`   | Ghost text only; the menu starts hidden and opens on the toggle key |

In mode 2 the toggle key hides and shows the **menu box only** — ghost text is never affected by it, which is what makes the "editor-like" behavior asked for in #102 possible. `menuOnlyHidden()` carries that rule so the three places that need it (the render, the debounce guard, the toggle handler) cannot drift apart.

**Existing configs keep working.** `ghost-text` was a boolean, so `UnmarshalTOML` reads `true` as `1` and `false` as `0`. `IRIS_UI_GHOST_TEXT` accepts both spellings too. Nothing to change on upgrade.

### Ghost text stays off when it is configured off (#140)

Enter, Ctrl+C, Ctrl+U and `iris reload` each reset ghost text with an unconditional `disableGhostText.Store(false)`, which turned it back on even with `ghost-text = 0`. They now respect the configured mode.

The matching re-enable in `renderMenuNow` is restored as well: Esc and unhandled keys disable ghost text only until the next key, and letting that outlive a render means `RenderGhostText` never runs to erase the glyphs already painted after the cursor, so they smear as the line is edited.

### Also

- Mid-line edits rank against the whole command instead of the prefix left of the cursor, so the ghost text stops re-ranking on every keystroke behind the cursor.
- `overlay.SetTypedQuery()` on history navigation, so ghost text is not derived from a stale query.
- fish's own autosuggestions are disabled only when iris ghost text is actually on.
- `ui.ghost-text` is range-validated (0-2) like `updater.auto-update` already was.

### Verification

- [x] `go build ./...`, `go vet ./...`, `go test ./...` (298 tests)
- [x] Legacy `true`/`false` configs verified end to end through `config.Load()` from a real file on disk
- [x] New tests: TOML bool/int decoding, range validation, env var parsing, fish autosuggestion gating, `menuOnlyHidden` table test

### Note on scope

This PR previously also carried the arrow-key work for #114. That has been split out — #114 is not addressed here and will be handled separately. The original 19 commits remain reachable from this PR's force-push history.
