### PR TITLE
fix(ci): nightly tags breaking release changelogs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,11 +55,14 @@ jobs:
             cd ..
           done
 
-      - name: Delete existing nightly release
+      - name: Delete previous nightly releases
+        # each run tags as v<version>-nightly.<sha>, a different name every
+        # time, so leftover nightly tags pile up and skew goreleaser's
+        # previous-tag detection for the next stable changelog
         run: |
-          gh release delete nightly --yes 2>/dev/null || true
-          git tag -d nightly 2>/dev/null || true
-          git push origin --delete nightly 2>/dev/null || true
+          for tag in $(git tag --list "v*-nightly.*"); do
+            gh release delete "$tag" --yes --cleanup-tag 2>/dev/null || true
+          done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,6 +2,13 @@ version: 2
 
 project_name: iris
 
+git:
+    # nightly tags share the version stream and can land on the same commit
+    # as a stable tag, which would make goreleaser diff the changelog against
+    # a nightly instead of the real previous stable release
+    ignore_tags:
+        - "*-nightly.*"
+
 builds:
     - env:
           - CGO_ENABLED=0


### PR DESCRIPTION
After released v0.5.0, I saw that v0.5.0 showed only 1 commit changelog instead of the real 16 commits since v0.4.21

Nightly builds tag every push to main, so a nightly tag can land on the exact same commit as a stable release tag
GoReleaser picked that nearby nightly as the `previous release` when building the changelog

Fixes:

- `.goreleaser.yaml`: added `git.ignore_tags`: ["*-nightly.*"] so changelog diffing skips nightly tags entirely
- `nightly.yml`: the cleanup step deleted a tag named `nightly`, but each run tags as `v<version>-nightly.<sha>`, so it never actually deleted anything and nightly tags piled up unbounded. Now deletes all previous `v*-nightly.*` tags/releases before creating the new one