### PR TITLE
fix(nix): update stale vendorHash for new go.mod dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
               subPackages = ["cmd/iris"];
 
               proxyVendor = true;
-              vendorHash = "sha256-KQNloP/Aj283YQ4d5LFu/2Pbb2HbVTZPhLK1fs4xvGw=";
+              vendorHash = "sha256-q1szUQkhdKq2VhMuWYYWTahmDxGeVjvHLmjciZu3cBU=";
 
               doCheck = false;
 


### PR DESCRIPTION
new dependencies added in #131 require updating the `vendorHash` in the nix flake