### PR TITLE
feat(config): add cobra-probe-enabled toggle option and safeguard cobra probing

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,15 +292,16 @@ iris config show
 
 ```toml
 [core]
-version = 1           # config schema version
-shell = ""            # "zsh", "bash", "fish", or empty for auto-detect
-shell-login = false   # run shell as a login shell (also: iris --shell-login)
-mode = "last"         # "last", "spec", or "history"
-debug = false         # verbose logging to iris.log (also: iris -d)
-expand-alias = true   # expand aliases before matching
-auto-execute = false  # run suggestion immediately instead of inserting it
-atuin-history = 0     # 0 = shell history, 1 = atuin, 2 = both
-atuin-db-path = ""    # path to atuin's history.db, empty = use default
+version = 1                    # config schema version
+shell = ""                     # "zsh", "bash", "fish", or empty for auto-detect
+shell-login = false            # run shell as a login shell (also: iris --shell-login)
+mode = "last"                  # "last", "spec", or "history"
+debug = false                  # verbose logging to iris.log (also: iris -d)
+expand-alias = true            # expand aliases before matching
+auto-execute = false           # run suggestion immediately instead of inserting it
+atuin-history = 0              # 0 = shell history, 1 = atuin, 2 = both
+atuin-db-path = ""             # path to atuin's history.db, empty = use default
+cobra-probe-allowlist = ["*"]  # binaries allowed to be probed with `__complete`, ["*"] allows any.
 
 [ui]
 style = "modern"       # "modern" or "classic"

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ expand-alias = true            # expand aliases before matching
 auto-execute = false           # run suggestion immediately instead of inserting it
 atuin-history = 0              # 0 = shell history, 1 = atuin, 2 = both
 atuin-db-path = ""             # path to atuin's history.db, empty = use default
-cobra-probe-allowlist = ["*"]  # binaries allowed to be probed with `__complete`, ["*"] allows any.
+cobra-probe-enabled = true     # fall back to probing cobra binaries for completions
 
 [ui]
 style = "modern"       # "modern" or "classic"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,16 +33,16 @@ func (d Duration) MarshalText() ([]byte, error) {
 }
 
 type CoreConfig struct {
-	Version             int    `toml:"version"`
-	Shell               string `toml:"shell"`
-	ShellLogin          bool   `toml:"shell-login"`
-	Mode                string `toml:"mode"`
-	Debug               bool   `toml:"debug"`
-	ExpandAlias         bool   `toml:"expand-alias"`
-	AutoExecute         bool   `toml:"auto-execute"`
+	Version     int    `toml:"version"`
+	Shell       string `toml:"shell"`
+	ShellLogin  bool   `toml:"shell-login"`
+	Mode        string `toml:"mode"`
+	Debug       bool   `toml:"debug"`
+	ExpandAlias bool   `toml:"expand-alias"`
+	AutoExecute bool   `toml:"auto-execute"`
 	// 0 = shell history, 1 = atuin only, 2 = atuin + shell
-	Atuin               int    `toml:"atuin-history"`
-	AtuinDBPath         string `toml:"atuin-db-path"`
+	Atuin               int      `toml:"atuin-history"`
+	AtuinDBPath         string   `toml:"atuin-db-path"`
 	CobraProbeAllowlist []string `toml:"cobra-probe-allowlist"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,9 +41,9 @@ type CoreConfig struct {
 	ExpandAlias bool   `toml:"expand-alias"`
 	AutoExecute bool   `toml:"auto-execute"`
 	// 0 = shell history, 1 = atuin only, 2 = atuin + shell
-	Atuin               int      `toml:"atuin-history"`
-	AtuinDBPath         string   `toml:"atuin-db-path"`
-	CobraProbeAllowlist []string `toml:"cobra-probe-allowlist"`
+	Atuin             int    `toml:"atuin-history"`
+	AtuinDBPath       string `toml:"atuin-db-path"`
+	CobraProbeEnabled bool   `toml:"cobra-probe-enabled"`
 }
 
 type UIConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,16 +33,17 @@ func (d Duration) MarshalText() ([]byte, error) {
 }
 
 type CoreConfig struct {
-	Version     int    `toml:"version"`
-	Shell       string `toml:"shell"`
-	ShellLogin  bool   `toml:"shell-login"`
-	Mode        string `toml:"mode"`
-	Debug       bool   `toml:"debug"`
-	ExpandAlias bool   `toml:"expand-alias"`
-	AutoExecute bool   `toml:"auto-execute"`
+	Version             int    `toml:"version"`
+	Shell               string `toml:"shell"`
+	ShellLogin          bool   `toml:"shell-login"`
+	Mode                string `toml:"mode"`
+	Debug               bool   `toml:"debug"`
+	ExpandAlias         bool   `toml:"expand-alias"`
+	AutoExecute         bool   `toml:"auto-execute"`
 	// 0 = shell history, 1 = atuin only, 2 = atuin + shell
-	Atuin       int    `toml:"atuin-history"`
-	AtuinDBPath string `toml:"atuin-db-path"`
+	Atuin               int    `toml:"atuin-history"`
+	AtuinDBPath         string `toml:"atuin-db-path"`
+	CobraProbeAllowlist []string `toml:"cobra-probe-allowlist"`
 }
 
 type UIConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -27,8 +27,8 @@ func TestDefaultConfigAndState(t *testing.T) {
 	if cfg.AI.Providers != nil {
 		t.Errorf("expected default providers map to be nil, got %v", cfg.AI.Providers)
 	}
-	if len(cfg.Core.CobraProbeAllowlist) != 1 || cfg.Core.CobraProbeAllowlist[0] != "*" {
-		t.Errorf("expected default cobra probe allowlist [\"*\"], got %v", cfg.Core.CobraProbeAllowlist)
+	if !cfg.Core.CobraProbeEnabled {
+		t.Errorf("expected cobra probing to be enabled by default")
 	}
 
 	// test manual provider registration

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -27,6 +27,9 @@ func TestDefaultConfigAndState(t *testing.T) {
 	if cfg.AI.Providers != nil {
 		t.Errorf("expected default providers map to be nil, got %v", cfg.AI.Providers)
 	}
+	if len(cfg.Core.CobraProbeAllowlist) != 1 || cfg.Core.CobraProbeAllowlist[0] != "*" {
+		t.Errorf("expected default cobra probe allowlist [\"*\"], got %v", cfg.Core.CobraProbeAllowlist)
+	}
 
 	// test manual provider registration
 	cfg.AI.Provider = "custom"

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -7,14 +7,14 @@ import (
 func DefaultConfig() *Config {
 	return &Config{
 		Core: CoreConfig{
-			Version:             1,
-			Shell:               "",
-			ShellLogin:          false,
-			Mode:                "last",
-			Debug:               false,
-			ExpandAlias:         true,
-			AutoExecute:         false,
-			CobraProbeAllowlist: []string{"*"},
+			Version:           1,
+			Shell:             "",
+			ShellLogin:        false,
+			Mode:              "last",
+			Debug:             false,
+			ExpandAlias:       true,
+			AutoExecute:       false,
+			CobraProbeEnabled: true,
 		},
 		UI: UIConfig{
 			Style:           "modern",

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -7,13 +7,14 @@ import (
 func DefaultConfig() *Config {
 	return &Config{
 		Core: CoreConfig{
-			Version:     1,
-			Shell:       "",
-			ShellLogin:  false,
-			Mode:        "last",
-			Debug:       false,
-			ExpandAlias: true,
-			AutoExecute: false,
+			Version:             1,
+			Shell:               "",
+			ShellLogin:          false,
+			Mode:                "last",
+			Debug:               false,
+			ExpandAlias:         true,
+			AutoExecute:         false,
+			CobraProbeAllowlist: []string{"*"},
 		},
 		UI: UIConfig{
 			Style:           "modern",

--- a/root/config_cmd.go
+++ b/root/config_cmd.go
@@ -65,10 +65,8 @@ atuin-history = 0
 # custom atuin database path (leave empty for default)
 atuin-db-path = ""
 
-# binaries allowed to be probed with ` + "`__complete`" + ` for Cobra-based CLI suggestions.
-# "*" allows any (default). use an explicit list (e.g. ["kubectl", "helm", "gh"]) to
-# only probe known-safe CLIs, or [] to disable probing entirely
-cobra-probe-allowlist = ["*"]
+# probe unknown binaries with ` + "`__complete`" + ` for Cobra-based CLI suggestions.
+cobra-probe-enabled = true
 
 [ui]
 # visual style: "modern" (icons, category pills, shortcut footer) or "classic" (minimalist, centered number, no icons)

--- a/root/config_cmd.go
+++ b/root/config_cmd.go
@@ -65,6 +65,11 @@ atuin-history = 0
 # custom atuin database path (leave empty for default)
 atuin-db-path = ""
 
+# binaries allowed to be probed with ` + "`__complete`" + ` for Cobra-based CLI suggestions.
+# "*" allows any (default). use an explicit list (e.g. ["kubectl", "helm", "gh"]) to
+# only probe known-safe CLIs, or [] to disable probing entirely
+cobra-probe-allowlist = ["*"]
+
 [ui]
 # visual style: "modern" (icons, category pills, shortcut footer) or "classic" (minimalist, centered number, no icons)
 style = "modern"

--- a/spec/cobra_complete.go
+++ b/spec/cobra_complete.go
@@ -96,17 +96,6 @@ func buildCobraCacheKey(binKey string, args []string, partial string) string {
 	return sb.String()
 }
 
-// cobraProbeAllowed reports whether binName is allowed to be probed, per
-// core.cobra-probe-allowlist. "*" allows any binary.
-func cobraProbeAllowed(binName string) bool {
-	for _, allowed := range config.Get().Core.CobraProbeAllowlist {
-		if allowed == "*" || allowed == binName {
-			return true
-		}
-	}
-	return false
-}
-
 // isLikelyCobraBinary reports whether binName is a Go binary linking Cobra.
 // only does static analysis so can produce false negatives and positives.
 func isLikelyCobraBinary(binName string) bool {
@@ -143,7 +132,7 @@ func QueryCobraComplete(binName string, args []string, partial string) []Suggest
 	if strings.ContainsAny(binName, `/\`) {
 		return nil
 	}
-	if !cobraProbeAllowed(binName) {
+	if !config.Get().Core.CobraProbeEnabled {
 		return nil
 	}
 

--- a/spec/cobra_complete.go
+++ b/spec/cobra_complete.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/versenilvis/iris/internal/config"
 )
 
 type cobraCacheEntry struct {
@@ -91,6 +93,17 @@ func buildCobraCacheKey(binKey string, args []string, partial string) string {
 	return sb.String()
 }
 
+// cobraProbeAllowed reports whether binName is allowed to be probed, per
+// core.cobra-probe-allowlist. "*" allows any binary.
+func cobraProbeAllowed(binName string) bool {
+	for _, allowed := range config.Get().Core.CobraProbeAllowlist {
+		if allowed == "*" || allowed == binName {
+			return true
+		}
+	}
+	return false
+}
+
 // newProbeCmd builds and isolates the `__complete` probe command.
 // starts the child in its own session so it has no controlling terminal
 // and therefore won't affect the user's tty in the case of programs that
@@ -106,6 +119,9 @@ func newProbeCmd(ctx context.Context, binName string, args []string) *exec.Cmd {
 // returns nil if the binary is not Cobra-based or times out.
 func QueryCobraComplete(binName string, args []string, partial string) []Suggestion {
 	if strings.ContainsAny(binName, `/\`) {
+		return nil
+	}
+	if !cobraProbeAllowed(binName) {
 		return nil
 	}
 

--- a/spec/cobra_complete.go
+++ b/spec/cobra_complete.go
@@ -2,6 +2,7 @@ package spec
 
 import (
 	"context"
+	"debug/buildinfo"
 	"os"
 	"os/exec"
 	"strconv"
@@ -12,6 +13,8 @@ import (
 
 	"github.com/versenilvis/iris/internal/config"
 )
+
+const cobraModulePath = "github.com/spf13/cobra"
 
 type cobraCacheEntry struct {
 	suggestions []Suggestion
@@ -104,6 +107,25 @@ func cobraProbeAllowed(binName string) bool {
 	return false
 }
 
+// isLikelyCobraBinary reports whether binName is a Go binary linking Cobra.
+// only does static analysis so can produce false negatives and positives.
+func isLikelyCobraBinary(binName string) bool {
+	path, err := exec.LookPath(binName)
+	if err != nil {
+		return false
+	}
+	info, err := buildinfo.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	for _, dep := range info.Deps {
+		if dep.Path == cobraModulePath {
+			return true
+		}
+	}
+	return false
+}
+
 // newProbeCmd builds and isolates the `__complete` probe command.
 // starts the child in its own session so it has no controlling terminal
 // and therefore won't affect the user's tty in the case of programs that
@@ -134,6 +156,10 @@ func QueryCobraComplete(binName string, args []string, partial string) []Suggest
 		return filterByPartial(entry.suggestions, partial)
 	}
 	cobraCacheMu.Unlock()
+
+	if !isLikelyCobraBinary(binName) {
+		return nil
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 	defer cancel()

--- a/spec/cobra_complete_test.go
+++ b/spec/cobra_complete_test.go
@@ -195,6 +195,26 @@ func TestCobraProbeAllowed(t *testing.T) {
 	}
 }
 
+func TestLooksLikeCobraBinary_NotGoBinary(t *testing.T) {
+	// 'ls' is a standard unix command that's not a go binary
+	if isLikelyCobraBinary("ls") {
+		t.Errorf("expected 'ls' to not look like a Cobra binary")
+	}
+}
+
+func TestLooksLikeCobraBinary_RealCobraBinary(t *testing.T) {
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "cobrafixture")
+	build := exec.Command("go", "build", "-o", binPath, "./testdata/cobrafixture")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("could not build fixture binary: %v: %s", err, out)
+	}
+
+	if !isLikelyCobraBinary(binPath) {
+		t.Errorf("expected fixture binary linking Cobra to look like a Cobra binary")
+	}
+}
+
 func TestLookup_CobraGolangciLint(t *testing.T) {
 	results := Lookup("golangci-lint ")
 	if len(results) == 0 {

--- a/spec/cobra_complete_test.go
+++ b/spec/cobra_complete_test.go
@@ -168,30 +168,17 @@ func TestNewProbeCmd_NoControllingTerminal(t *testing.T) {
 	}
 }
 
-func TestCobraProbeAllowed(t *testing.T) {
+func TestQueryCobraComplete_ProbeDisabled(t *testing.T) {
+	t.Cleanup(ResetCobraCache)
 	original := config.Get()
 	t.Cleanup(func() { config.Init(original) })
 
 	cfg := config.DefaultConfig()
-	cfg.Core.CobraProbeAllowlist = []string{"*"}
+	cfg.Core.CobraProbeEnabled = false
 	config.Init(cfg)
-	if !cobraProbeAllowed("anything") {
-		t.Errorf("expected wildcard allowlist to allow any binary")
-	}
 
-	cfg.Core.CobraProbeAllowlist = []string{"kubectl", "gh"}
-	config.Init(cfg)
-	if !cobraProbeAllowed("kubectl") {
-		t.Errorf("expected listed binary 'kubectl' to be allowed")
-	}
-	if cobraProbeAllowed("fakecobra") {
-		t.Errorf("expected unlisted binary 'fakecobra' to be denied")
-	}
-
-	cfg.Core.CobraProbeAllowlist = []string{}
-	config.Init(cfg)
-	if cobraProbeAllowed("kubectl") {
-		t.Errorf("expected empty allowlist to deny everything")
+	if result := QueryCobraComplete("non-go-binary", nil, ""); result != nil {
+		t.Errorf("expected nil when cobra probing is disabled, got %v", result)
 	}
 }
 

--- a/spec/cobra_complete_test.go
+++ b/spec/cobra_complete_test.go
@@ -205,7 +205,7 @@ func TestLooksLikeCobraBinary_NotGoBinary(t *testing.T) {
 func TestLooksLikeCobraBinary_RealCobraBinary(t *testing.T) {
 	dir := t.TempDir()
 	binPath := filepath.Join(dir, "cobrafixture")
-	build := exec.Command("go", "build", "-o", binPath, "./testdata/cobrafixture")
+	build := exec.CommandContext(context.Background(), "go", "build", "-o", binPath, "./testdata/cobrafixture")
 	if out, err := build.CombinedOutput(); err != nil {
 		t.Fatalf("could not build fixture binary: %v: %s", err, out)
 	}

--- a/spec/cobra_complete_test.go
+++ b/spec/cobra_complete_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/versenilvis/iris/internal/config"
 )
 
 func TestParseCobraOutput_ValidCobra(t *testing.T) {
@@ -163,6 +165,33 @@ func TestNewProbeCmd_NoControllingTerminal(t *testing.T) {
 	var exitErr *exec.ExitError
 	if !errors.As(runErr, &exitErr) {
 		t.Fatalf("expected probe script to exit nonzero after failing to open /dev/tty, got %v", runErr)
+	}
+}
+
+func TestCobraProbeAllowed(t *testing.T) {
+	original := config.Get()
+	t.Cleanup(func() { config.Init(original) })
+
+	cfg := config.DefaultConfig()
+	cfg.Core.CobraProbeAllowlist = []string{"*"}
+	config.Init(cfg)
+	if !cobraProbeAllowed("anything") {
+		t.Errorf("expected wildcard allowlist to allow any binary")
+	}
+
+	cfg.Core.CobraProbeAllowlist = []string{"kubectl", "gh"}
+	config.Init(cfg)
+	if !cobraProbeAllowed("kubectl") {
+		t.Errorf("expected listed binary 'kubectl' to be allowed")
+	}
+	if cobraProbeAllowed("fakecobra") {
+		t.Errorf("expected unlisted binary 'fakecobra' to be denied")
+	}
+
+	cfg.Core.CobraProbeAllowlist = []string{}
+	config.Init(cfg)
+	if cobraProbeAllowed("kubectl") {
+		t.Errorf("expected empty allowlist to deny everything")
 	}
 }
 

--- a/spec/testdata/cobrafixture/main.go
+++ b/spec/testdata/cobrafixture/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "github.com/spf13/cobra"
+
+// minimal Cobra CLI, built at test time as a fixture for TestLooksLikeCobraBinary_RealCobraBinary
+func main() {
+	root := &cobra.Command{Use: "cobrafixture"}
+	_ = root.Execute()
+}


### PR DESCRIPTION
currently, every command that doesn't have a completion spec is assumed to be a cobra cli and it gets ran with a `__complete` argument. for non cobra clis this can cause problems if those non-cobra clis have sideeffects even when ran with the `__complete` argument, and there is no way to disable this.
one of these problems was solved at #111, but a full solution would probably require actual sandboxing which is i think is an overkill just for attempting to get suggestions for unrecognized commands. instead of sandboxing, this pr adds a config option for allowing only selected commands to be probed and disallowing the rest.
currently the default is still allowing all (`["*"]`) so default behavior is the same, but it might be better to just have a long list of known cobra clis as the default instead.

here's a demo of a side effect caused by the probing, in this case "deleting" a file with rmtrash without actually trying to run the command:
https://github.com/user-attachments/assets/5256d363-5291-42e8-bb4f-cf7467927246
