### PR TITLE
fix(wrapper): don't let fish's alt-screen probe permanently hide the overlay

### DIFF
--- a/root/wrapper.go
+++ b/root/wrapper.go
@@ -317,7 +317,12 @@ func runWrapper() {
 	})
 	isExecuting := func() bool {
 		if isAltScreenActive.Load() {
-			return true
+			pgrp, pgrpErr := unix.IoctlGetInt(int(ptmx.Fd()), unix.TIOCGPGRP)
+			if pgrpErr == nil && pgrp == shellPGID {
+				isAltScreenActive.Store(false)
+			} else {
+				return true
+			}
 		}
 		if isCommandActive.Load() {
 			// for bash: no preexec/precmd hooks, so fall back to TIOCGPGRP to detect when shell returns


### PR DESCRIPTION
fixes #139  
fish's own startup terminal probe was misread as a full screen app taking over, permanently suppressing suggestions