### PR TITLE
fix(watchdog): follow the shell's working directory in the watchdog process

### DIFF
--- a/root/root.go
+++ b/root/root.go
@@ -1,10 +1,12 @@
 package root
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -77,6 +79,19 @@ func init() {
 	}
 }
 
+// relayWatchdogCWD reads null-delimited cwd updates the wrapper relays over
+// r and applies each one to the watchdog's own working directory.
+func relayWatchdogCWD(r io.Reader) {
+	scanner := bufio.NewScanner(r)
+	scanner.Split(nullTokenSplit)
+	for scanner.Scan() {
+		syncProcessCWD(scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		logger.Errorf("watchdog cwd relay scanner error: %v", err)
+	}
+}
+
 // runWatchdog spawns the watchdog parent process
 func runWatchdog() {
 	exe, err := os.Executable()
@@ -114,6 +129,17 @@ func runWatchdog() {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = w
 
+	// give the wrapper a pipe to relay the shell's cwd back to the watchdog
+	// so it doesn't stay stuck at its initial working directory
+	// the watchdog holds the outer tty, so it's the process external tools
+	// inspect to resolve this session's cwd.
+	cwdR, cwdW, cwdErr := os.Pipe()
+	if cwdErr == nil {
+		cwdFD := 3 + len(cmd.ExtraFiles)
+		cmd.ExtraFiles = append(cmd.ExtraFiles, cwdW)
+		cmd.Env = append(cmd.Env, fmt.Sprintf("IRIS_WATCHDOG_CWD_FD=%d", cwdFD))
+	}
+
 	err = cmd.Start()
 	if err != nil {
 		runOriginal()
@@ -121,6 +147,10 @@ func runWatchdog() {
 	}
 
 	_ = w.Close()
+	if cwdErr == nil {
+		_ = cwdW.Close()
+		go relayWatchdogCWD(cwdR)
+	}
 
 	// copy child stderr to both our buffer and the real stderr, filtering out panics
 	var stderrBuf bytes.Buffer

--- a/root/root_test.go
+++ b/root/root_test.go
@@ -1,0 +1,30 @@
+package root
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestRelayWatchdogCWDAppliesLatestOfMultipleWrites(t *testing.T) {
+	firstDir := t.TempDir()
+	secondDir := t.TempDir()
+	t.Chdir(t.TempDir())
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fmt.Fprintf(w, "%s\x00%s\x00", firstDir, secondDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	relayWatchdogCWD(r)
+
+	if got := currentDir(t); got != wantDir(t, secondDir) {
+		t.Fatalf("relayWatchdogCWD left cwd at %q, want the last write %q", got, wantDir(t, secondDir))
+	}
+}

--- a/root/wrapper.go
+++ b/root/wrapper.go
@@ -135,6 +135,21 @@ func syncProcessCWD(cwd string) {
 	_ = os.Chdir(cwd)
 }
 
+// nullTokenSplit is a bufio.SplitFunc for the null-byte-delimited messages
+// iris passes over its IPC pipes.
+func nullTokenSplit(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	if i := bytes.IndexByte(data, '\x00'); i >= 0 {
+		return i + 1, data[0:i], nil
+	}
+	if atEOF {
+		return len(data), data, nil
+	}
+	return 0, nil, nil
+}
+
 // runWrapper sets up the pty environment, launches the shell,
 // and manages the main input loop to provide real-time suggestions
 // it handles raw terminal mode to intercept keystrokes and
@@ -153,6 +168,15 @@ func runWrapper() {
 	r, w, err := os.Pipe() // pipe for ipc communication from shell to iris
 	if err != nil {
 		return
+	}
+
+	// relay cwd changes up to the watchdog over the fd it handed the wrapper so external tools
+	// don't just see the initial working directory
+	var watchdogCWD *os.File
+	if fdStr := os.Getenv("IRIS_WATCHDOG_CWD_FD"); fdStr != "" {
+		if fd, fdErr := strconv.Atoi(fdStr); fdErr == nil {
+			watchdogCWD = os.NewFile(uintptr(fd), "watchdog-cwd-relay")
+		}
 	}
 
 	var shellName string
@@ -515,18 +539,7 @@ func runWrapper() {
 			}
 		}()
 		scanner := bufio.NewScanner(r)
-		scanner.Split(func(data []byte, atEOF bool) (advance int, token []byte, err error) {
-			if atEOF && len(data) == 0 {
-				return 0, nil, nil
-			}
-			if i := bytes.IndexByte(data, '\x00'); i >= 0 {
-				return i + 1, data[0:i], nil
-			}
-			if atEOF {
-				return len(data), data, nil
-			}
-			return 0, nil, nil
-		})
+		scanner.Split(nullTokenSplit)
 
 		for scanner.Scan() {
 			query := scanner.Text()
@@ -534,6 +547,9 @@ func runWrapper() {
 			if cwd, ok := strings.CutPrefix(query, "IRIS_CWD:"); ok {
 				spec.SetCWD(cwd)
 				syncProcessCWD(cwd)
+				if watchdogCWD != nil {
+					_, _ = fmt.Fprintf(watchdogCWD, "%s\x00", cwd)
+				}
 				continue
 			}
 

--- a/root/wrapper_test.go
+++ b/root/wrapper_test.go
@@ -98,3 +98,39 @@ func TestSyncProcessCWDKeepsDirectoryOnBadPath(t *testing.T) {
 		}
 	}
 }
+
+func TestNullTokenSplit(t *testing.T) {
+	tests := []struct {
+		name        string // subtest name
+		data        string // input data
+		atEOF       bool   // is at eof
+		wantAdvance int    // expected bytes consumed
+		wantToken   string // expected token returned
+		wantMore    bool   // wants more data before producing a token
+	}{
+		{"empty at eof", "", true, 0, "", true},
+		{"complete token", "/some/dir\x00rest", false, len("/some/dir\x00"), "/some/dir", false},
+		{"partial token, not at eof", "/some/dir", false, 0, "", true},
+		{"partial token at eof is returned as final token", "/some/dir", true, len("/some/dir"), "/some/dir", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			advance, token, err := nullTokenSplit([]byte(tt.data), tt.atEOF)
+			if err != nil {
+				t.Fatalf("nullTokenSplit(%q, %v) returned error: %v", tt.data, tt.atEOF, err)
+			}
+			if advance != tt.wantAdvance {
+				t.Errorf("advance = %d, want %d", advance, tt.wantAdvance)
+			}
+			if tt.wantMore {
+				if token != nil {
+					t.Errorf("token = %q, want nil (more data needed)", token)
+				}
+				return
+			}
+			if string(token) != tt.wantToken {
+				t.Errorf("token = %q, want %q", token, tt.wantToken)
+			}
+		})
+	}
+}


### PR DESCRIPTION
had a problem with tmux's `pane_current_path` always staying at the initial path where iris was launched instead of the cwd of the shell. when i looked for existing open issues i found that a fix to a similar problem was made at #129, but it mentioned:
> One limitation: the outer launcher process keeps its start directory [...]

this pr fixes that limitation by relaying each cwd update the wrapper receives over a dedicated pipe to the watchdog, which applies it in a background goroutine.