### PR TITLE
fix(shell): parse fish aliases and abbreviations

### DIFF
--- a/integration/icons.go
+++ b/integration/icons.go
@@ -122,6 +122,7 @@ var iconMap = map[string]string{
 	"zip":            "",
 	"unzip":          "",
 	"alias":          "",
+	"abbr":           "",
 	"history":        "",
 	"atuin":          "󰳗",
 	"system":         "",

--- a/integration/shell/adapter.go
+++ b/integration/shell/adapter.go
@@ -223,8 +223,11 @@ func ScanPosixAliases(files []string) map[string]string {
 	aliases := make(map[string]string)
 	stamps := make(map[string]fileStamp)
 	visited := make(map[string]bool)
+	walk := func(data string, onSource func(target string)) {
+		walkShellConfig(data, aliases, onSource)
+	}
 	for _, path := range paths {
-		scanAliasFile(path, aliases, visited, stamps, 0)
+		scanConfigFile(path, walk, visited, stamps, 0)
 	}
 
 	aliasScanCache.entryPoints = paths
@@ -241,26 +244,35 @@ func cachedAliases(paths []string) map[string]string {
 	if aliasScanCache.aliases == nil || !slices.Equal(aliasScanCache.entryPoints, paths) {
 		return nil
 	}
-	for path, want := range aliasScanCache.stamps {
-		got, ok := statStamp(path)
-		if want == (fileStamp{}) {
-			// Was missing at scan time; it appearing is a change.
-			if ok {
-				return nil
-			}
-			continue
-		}
-		if !ok || got != want {
-			return nil
-		}
+	if !stampsUnchanged(aliasScanCache.stamps) {
+		return nil
 	}
 	return maps.Clone(aliasScanCache.aliases)
 }
 
-// scanAliasFile records the aliases defined in path, following any file it
-// sources. Most real configs keep aliases in a dedicated file pulled in with
-// `source`, so reading only the entry points would miss nearly all of them.
-func scanAliasFile(path string, aliases map[string]string, visited map[string]bool, stamps map[string]fileStamp, depth int) {
+func stampsUnchanged(stamps map[string]fileStamp) bool {
+	for path, want := range stamps {
+		got, ok := statStamp(path)
+		if want == (fileStamp{}) {
+			// Was missing at scan time; it appearing is a change.
+			if ok {
+				return false
+			}
+			continue
+		}
+		if !ok || got != want {
+			return false
+		}
+	}
+	return true
+}
+
+type configWalker func(data string, onSource func(target string))
+
+// scanConfigFile follows any file path sources. Most real configs keep aliases
+// in a dedicated file pulled in with `source`, so reading only the entry points
+// would miss nearly all of them.
+func scanConfigFile(path string, walk configWalker, visited map[string]bool, stamps map[string]fileStamp, depth int) {
 	if depth > maxSourceDepth {
 		return
 	}
@@ -287,8 +299,8 @@ func scanAliasFile(path string, aliases map[string]string, visited map[string]bo
 		return
 	}
 
-	walkShellConfig(string(data), aliases, func(target string) {
-		scanAliasFile(target, aliases, visited, stamps, depth+1)
+	walk(string(data), func(target string) {
+		scanConfigFile(target, walk, visited, stamps, depth+1)
 	})
 }
 

--- a/integration/shell/adapter.go
+++ b/integration/shell/adapter.go
@@ -164,7 +164,7 @@ func GetFishConfigDir() string {
 	fishConfigDirOnce.Do(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 		defer cancel()
-		cmd := exec.CommandContext(ctx, "fish", "-c", "echo $__fish_config_dir")
+		cmd := exec.CommandContext(ctx, "fish", "--no-config", "-c", "echo $__fish_config_dir")
 		out, err := cmd.Output()
 		if err == nil {
 			fishConfigDirCached = strings.TrimSpace(string(out))

--- a/integration/shell/adapter.go
+++ b/integration/shell/adapter.go
@@ -46,6 +46,10 @@ type Adapter interface {
 	ScanAliases() map[string]string
 }
 
+type AbbrScanner interface {
+	ScanAbbrs() map[string]string
+}
+
 // Current shell instance
 var Current Adapter
 
@@ -147,11 +151,38 @@ func (f *FishAdapter) PrepareSelectSequence(selected string, cursorFromEnd int) 
 	return ReplaceLine([]byte(selected), cursorFromEnd)
 }
 func (f *FishAdapter) ScanAliases() map[string]string {
-	// fish uses 'alias' command in config.fish or separate function files
-	return ScanPosixAliases([]string{filepath.Join(GetFishConfigDir(), "config.fish")})
+	return scanFishDefs(GetFishConfigDir()).aliases
+}
+
+func (f *FishAdapter) ScanAbbrs() map[string]string {
+	return scanFishDefs(GetFishConfigDir()).abbrs
 }
 
 func GetFishConfigDir() string {
+	// $__fish_config_dir is a shell variable rather than an env var, so it is
+	// resolved once per process the same way ZDOTDIR is.
+	fishConfigDirOnce.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "fish", "-c", "echo $__fish_config_dir")
+		out, err := cmd.Output()
+		if err == nil {
+			fishConfigDirCached = strings.TrimSpace(string(out))
+		}
+		if fishConfigDirCached == "" {
+			fishConfigDirCached = defaultFishConfigDir()
+		}
+	})
+
+	return fishConfigDirCached
+}
+
+var (
+	fishConfigDirOnce   sync.Once
+	fishConfigDirCached string
+)
+
+func defaultFishConfigDir() string {
 	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
 		return filepath.Join(xdg, "fish")
 	}

--- a/integration/shell/fish.go
+++ b/integration/shell/fish.go
@@ -1,0 +1,513 @@
+package shell
+
+import (
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+type fishDefs struct {
+	aliases map[string]string
+	abbrs   map[string]string
+}
+
+// Aliases and abbreviations share one entry: scanning them separately would
+// make each call evict the other's result, re-reading the tree every keystroke.
+var fishScanCache struct {
+	sync.Mutex
+	dir    string
+	stamps map[string]fileStamp
+	defs   fishDefs
+}
+
+func scanFishDefs(dir string) fishDefs {
+	fishScanCache.Lock()
+	defer fishScanCache.Unlock()
+
+	if fishScanCache.defs.aliases != nil && fishScanCache.dir == dir && stampsUnchanged(fishScanCache.stamps) {
+		return cloneFishDefs(fishScanCache.defs)
+	}
+
+	defs := fishDefs{aliases: map[string]string{}, abbrs: map[string]string{}}
+	stamps := make(map[string]fileStamp)
+	visited := make(map[string]bool)
+	walk := func(data string, onSource func(target string)) {
+		walkFishConfig(dir, data, defs, onSource)
+	}
+
+	files, dirs := fishConfigFiles(dir)
+	// A file added to conf.d/ leaves every scanned file untouched, so only the
+	// directory's own stamp can invalidate the cache.
+	for _, d := range dirs {
+		stamps[d], _ = statStamp(d)
+	}
+	for _, path := range files {
+		scanConfigFile(path, walk, visited, stamps, 0)
+	}
+
+	fishScanCache.dir = dir
+	fishScanCache.stamps = stamps
+	fishScanCache.defs = defs
+
+	return cloneFishDefs(defs)
+}
+
+func cloneFishDefs(defs fishDefs) fishDefs {
+	return fishDefs{aliases: maps.Clone(defs.aliases), abbrs: maps.Clone(defs.abbrs)}
+}
+
+func fishConfigFiles(dir string) ([]string, []string) {
+	functions := filepath.Join(dir, "functions")
+	confd := filepath.Join(dir, "conf.d")
+
+	// An autoloaded function only loads while its name is still undefined, so
+	// an `alias --save` file loses to whatever conf.d and config.fish define.
+	files := fishFiles(functions)
+	files = append(files, fishFiles(confd)...)
+	files = append(files, filepath.Join(dir, "config.fish"))
+
+	return files, []string{functions, confd}
+}
+
+func fishFiles(dir string) []string {
+	matches, err := filepath.Glob(filepath.Join(dir, "*.fish"))
+	if err != nil {
+		return nil
+	}
+	return matches
+}
+
+type fishBlock struct {
+	branching  bool
+	arms       int
+	suppressed bool
+}
+
+func walkFishConfig(dir, data string, defs fishDefs, onSource func(target string)) {
+	// fish closes every block with `end`, so `for`/`function`/`begin` need
+	// tracking too or their `end` pops the enclosing `if` and the fallback arm
+	// starts overwriting the preferred one.
+	var stack []fishBlock
+	altArm := 0
+
+	vars := map[string][]string{}
+	if dir != "" {
+		vars["__fish_config_dir"] = []string{dir}
+	}
+
+	for _, line := range fishLogicalLines(data) {
+		for _, segment := range splitShellSegments(stripFishComment(line)) {
+			segment = trimFishModifiers(strings.TrimSpace(segment))
+			if segment == "" {
+				continue
+			}
+
+			switch firstWord(segment) {
+			case "else", "case":
+				if n := len(stack) - 1; n >= 0 {
+					stack[n].arms++
+					if stack[n].branching && stack[n].arms > 1 && !stack[n].suppressed {
+						stack[n].suppressed = true
+						altArm++
+					}
+				}
+			case "end":
+				if n := len(stack) - 1; n >= 0 {
+					if stack[n].suppressed {
+						altArm--
+					}
+					stack = stack[:n]
+				}
+			case "if":
+				// the `if` line is already the first arm; `switch` has none
+				// until its first `case`
+				stack = append(stack, fishBlock{branching: true, arms: 1})
+			case "switch":
+				stack = append(stack, fishBlock{branching: true})
+			case "for", "while", "begin", "function":
+				stack = append(stack, fishBlock{})
+			}
+
+			parseFishSet(segment, vars)
+			parseFishFor(segment, vars)
+
+			if onSource != nil {
+				for _, target := range fishSourceTargets(segment, vars) {
+					onSource(target)
+				}
+			}
+
+			if altArm > 0 {
+				continue
+			}
+			parseFishAlias(segment, defs.aliases)
+			parseFishAliasFunction(segment, defs.aliases)
+			parseFishAbbr(segment, defs.abbrs)
+		}
+	}
+}
+
+func ParseFishConfig(dir, data string) (map[string]string, map[string]string) {
+	defs := fishDefs{aliases: map[string]string{}, abbrs: map[string]string{}}
+	walkFishConfig(dir, data, defs, nil)
+	return defs.aliases, defs.abbrs
+}
+
+// A `\` at end of line continues the statement, and real configs use it to
+// spread a `set` list over many lines.
+func fishLogicalLines(data string) []string {
+	var lines []string
+	var joined strings.Builder
+
+	for line := range strings.SplitSeq(data, "\n") {
+		trimmed := strings.TrimRight(line, " \t")
+		if strings.HasSuffix(trimmed, `\`) && !strings.HasSuffix(trimmed, `\\`) {
+			joined.WriteString(strings.TrimSuffix(trimmed, `\`))
+			joined.WriteString(" ")
+			continue
+		}
+		joined.WriteString(line)
+		lines = append(lines, joined.String())
+		joined.Reset()
+	}
+	if joined.Len() > 0 {
+		lines = append(lines, joined.String())
+	}
+	return lines
+}
+
+func firstWord(segment string) string {
+	if i := strings.IndexAny(segment, " \t"); i >= 0 {
+		return segment[:i]
+	}
+	return segment
+}
+
+func stripFishComment(line string) string {
+	inQuote := false
+	var quoteChar rune
+	// fish only starts a comment at a word boundary, so `echo foo#bar` keeps
+	// its hash.
+	atWordStart := true
+
+	for i, c := range line {
+		switch {
+		case !inQuote && (c == '"' || c == '\''):
+			inQuote = true
+			quoteChar = c
+		case inQuote && c == quoteChar:
+			inQuote = false
+		case !inQuote && c == '#' && atWordStart:
+			return line[:i]
+		}
+		atWordStart = c == ' ' || c == '\t'
+	}
+	return line
+}
+
+func trimFishModifiers(segment string) string {
+	modifiers := map[string]bool{"and": true, "or": true, "not": true, "command": true, "builtin": true}
+	for modifiers[firstWord(segment)] {
+		_, rest, _ := strings.Cut(segment, " ")
+		segment = strings.TrimSpace(rest)
+	}
+	return segment
+}
+
+func cutFishCommand(segment, name string) (string, bool) {
+	if firstWord(segment) != name {
+		return "", false
+	}
+	rest := strings.TrimSpace(segment[len(name):])
+	return rest, rest != ""
+}
+
+func fishSourceTargets(segment string, vars map[string][]string) []string {
+	rest, ok := cutFishCommand(segment, "source")
+	if !ok {
+		if rest, ok = cutFishCommand(segment, "."); !ok {
+			return nil
+		}
+	}
+
+	fields := SplitAliasTokens(rest)
+	// fish spells command substitution as a bare (cmd), which expandConfigPath
+	// has no way to recognize.
+	if len(fields) == 0 || strings.Contains(fields[0], "(") {
+		return nil
+	}
+
+	candidates, ok := expandFishToken(fields[0], vars)
+	if !ok {
+		return nil
+	}
+
+	targets := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		if path, ok := expandConfigPath(candidate); ok {
+			targets = append(targets, path)
+		}
+	}
+	return targets
+}
+
+// Config files routinely reach their real content through `set`/`for` rather
+// than a literal path, so those two have to be resolved or `source` finds
+// nothing to follow.
+func parseFishSet(segment string, vars map[string][]string) {
+	rest, ok := cutFishCommand(segment, "set")
+	if !ok {
+		return
+	}
+
+	reject := map[string]bool{
+		"-e": true, "--erase": true, "-q": true, "--query": true,
+		"-S": true, "--show": true, "-h": true, "--help": true,
+	}
+	positional, ok := fishPositionals(SplitAliasTokens(rest), nil, reject)
+	if !ok || len(positional) == 0 {
+		return
+	}
+
+	name := unquoteAliasValue(positional[0])
+	if name == "" || strings.ContainsAny(name, "$[") {
+		return
+	}
+
+	values := make([]string, 0, len(positional)-1)
+	for _, token := range positional[1:] {
+		expanded, ok := expandFishToken(token, vars)
+		if !ok {
+			delete(vars, name)
+			return
+		}
+		values = append(values, expanded...)
+	}
+	vars[name] = values
+}
+
+func parseFishFor(segment string, vars map[string][]string) {
+	rest, ok := cutFishCommand(segment, "for")
+	if !ok {
+		return
+	}
+
+	tokens := SplitAliasTokens(rest)
+	if len(tokens) < 3 || tokens[1] != "in" {
+		return
+	}
+
+	name := unquoteAliasValue(tokens[0])
+	if name == "" {
+		return
+	}
+
+	// every iteration is followed at once, since which one the shell takes
+	// cannot be known from the text
+	values := make([]string, 0, len(tokens)-2)
+	for _, token := range tokens[2:] {
+		expanded, ok := expandFishToken(token, vars)
+		if !ok {
+			delete(vars, name)
+			return
+		}
+		values = append(values, expanded...)
+	}
+	vars[name] = values
+}
+
+func expandFishToken(token string, vars map[string][]string) ([]string, bool) {
+	// fish leaves single-quoted text alone
+	if strings.HasPrefix(token, "'") {
+		return []string{unquoteAliasValue(token)}, true
+	}
+	return expandFishWord(unquoteAliasValue(token), vars)
+}
+
+const maxFishExpansion = 64
+
+func expandFishWord(word string, vars map[string][]string) ([]string, bool) {
+	results := []string{""}
+
+	for {
+		before, after, ok := strings.Cut(word, "$")
+		if !ok {
+			for i := range results {
+				results[i] += word
+			}
+			return results, true
+		}
+
+		name, rest := cutFishVarName(after)
+		values, ok := fishVarValues(name, vars)
+		if !ok {
+			return nil, false
+		}
+
+		head := before
+		expanded := make([]string, 0, len(results)*len(values))
+		for _, prefix := range results {
+			for _, value := range values {
+				expanded = append(expanded, prefix+head+value)
+			}
+		}
+		if len(expanded) > maxFishExpansion {
+			return nil, false
+		}
+		results, word = expanded, rest
+	}
+}
+
+func fishVarValues(name string, vars map[string][]string) ([]string, bool) {
+	if name == "" {
+		return nil, false
+	}
+	if values, ok := vars[name]; ok {
+		return values, len(values) > 0
+	}
+	if value, ok := os.LookupEnv(name); ok && value != "" {
+		return []string{value}, true
+	}
+	return nil, false
+}
+
+func cutFishVarName(s string) (string, string) {
+	s = strings.TrimPrefix(s, "{")
+	end := 0
+	for end < len(s) && (s[end] == '_' ||
+		(s[end] >= 'a' && s[end] <= 'z') ||
+		(s[end] >= 'A' && s[end] <= 'Z') ||
+		(s[end] >= '0' && s[end] <= '9')) {
+		end++
+	}
+	return s[:end], strings.TrimPrefix(s[end:], "}")
+}
+
+func fishPositionals(tokens []string, valueFlags, reject map[string]bool) ([]string, bool) {
+	for i := 0; i < len(tokens); i++ {
+		token := tokens[i]
+		if token == "--" {
+			return tokens[i+1:], true
+		}
+		if len(token) < 2 || !strings.HasPrefix(token, "-") {
+			return tokens[i:], true
+		}
+
+		flag, _, hasValue := strings.Cut(token, "=")
+		if reject[flag] {
+			return nil, false
+		}
+		if !hasValue && valueFlags[flag] {
+			i++
+		}
+	}
+	return nil, true
+}
+
+func parseFishAlias(segment string, aliases map[string]string) {
+	rest, ok := cutFishCommand(segment, "alias")
+	if !ok {
+		return
+	}
+
+	tokens, ok := fishPositionals(SplitAliasTokens(rest), nil, nil)
+	if !ok || len(tokens) == 0 || !isLiteralFishToken(tokens[0]) {
+		return
+	}
+
+	name, target := fishAliasNameAndTarget(tokens)
+	if name == "" || target == "" {
+		return
+	}
+	aliases[name] = target
+}
+
+// A name the shell computes -- `(string split ...)`, `$tool` -- is not a name
+// iris can suggest. Single quotes make it literal, so `'!$'` still counts.
+func isLiteralFishToken(token string) bool {
+	if strings.HasPrefix(token, "'") {
+		return true
+	}
+	return !strings.ContainsAny(token, "$()")
+}
+
+func fishAliasNameAndTarget(tokens []string) (string, string) {
+	if len(tokens) == 0 {
+		return "", ""
+	}
+
+	parts := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		parts = append(parts, unquoteAliasValue(token))
+	}
+
+	// `alias name=value` still spills the rest of the value into later tokens
+	if name, head, ok := strings.Cut(parts[0], "="); ok {
+		parts[0] = unquoteAliasValue(head)
+		return strings.TrimSpace(name), strings.TrimSpace(strings.Join(parts, " "))
+	}
+	return strings.TrimSpace(parts[0]), strings.TrimSpace(strings.Join(parts[1:], " "))
+}
+
+func parseFishAbbr(segment string, abbrs map[string]string) {
+	rest, ok := cutFishCommand(segment, "abbr")
+	if !ok {
+		return
+	}
+
+	// --regex leaves no literal name and --function builds the expansion at
+	// runtime, so neither can be recovered from static text.
+	reject := map[string]bool{
+		"-r": true, "--regex": true, "-f": true, "--function": true,
+		"-e": true, "--erase": true, "--rename": true,
+		"-q": true, "--query": true, "-s": true, "--show": true,
+		"-l": true, "--list": true, "-h": true, "--help": true,
+	}
+	valueFlags := map[string]bool{
+		"--position": true, "-c": true, "--command": true, "--color": true,
+	}
+
+	tokens, ok := fishPositionals(SplitAliasTokens(rest), valueFlags, reject)
+	if !ok || len(tokens) < 2 || !isLiteralFishToken(tokens[0]) {
+		return
+	}
+
+	name := strings.TrimSpace(unquoteAliasValue(tokens[0]))
+	parts := make([]string, 0, len(tokens)-1)
+	for _, token := range tokens[1:] {
+		parts = append(parts, unquoteAliasValue(token))
+	}
+
+	expansion := strings.TrimSpace(strings.Join(parts, " "))
+	if name == "" || expansion == "" {
+		return
+	}
+	abbrs[name] = expansion
+}
+
+// `alias --save` is the only writer of functions/, and it records the original
+// definition verbatim in the function's description.
+func parseFishAliasFunction(segment string, aliases map[string]string) {
+	rest, ok := cutFishCommand(segment, "function")
+	if !ok {
+		return
+	}
+
+	tokens := SplitAliasTokens(rest)
+	for i, token := range tokens {
+		flag, value, hasValue := strings.Cut(token, "=")
+		if flag != "--description" && flag != "-d" {
+			continue
+		}
+		if !hasValue {
+			if i+1 >= len(tokens) {
+				return
+			}
+			value = tokens[i+1]
+		}
+		parseFishAlias(unquoteAliasValue(value), aliases)
+		return
+	}
+}

--- a/integration/shell/fish.go
+++ b/integration/shell/fish.go
@@ -496,6 +496,11 @@ func parseFishAliasFunction(segment string, aliases map[string]string) {
 	}
 
 	tokens := SplitAliasTokens(rest)
+	if len(tokens) == 0 {
+		return
+	}
+	name := unquoteAliasValue(tokens[0])
+
 	for i, token := range tokens {
 		flag, value, hasValue := strings.Cut(token, "=")
 		if flag != "--description" && flag != "-d" {
@@ -507,7 +512,11 @@ func parseFishAliasFunction(segment string, aliases map[string]string) {
 			}
 			value = tokens[i+1]
 		}
-		parseFishAlias(unquoteAliasValue(value), aliases)
+		described := map[string]string{}
+		parseFishAlias(unquoteAliasValue(value), described)
+		if target, ok := described[name]; ok {
+			aliases[name] = target
+		}
 		return
 	}
 }

--- a/integration/shell/fish_test.go
+++ b/integration/shell/fish_test.go
@@ -155,6 +155,10 @@ end
 function greet --description 'say hello'
     echo hello
 end
+
+function ff --description 'alias for finding files'
+    fd $argv
+end
 `
 	expected := map[string]string{
 		"gst": "git status -sb",

--- a/integration/shell/fish_test.go
+++ b/integration/shell/fish_test.go
@@ -1,0 +1,307 @@
+package shell
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestParseFishConfigAliasForms(t *testing.T) {
+	input := `
+alias clear 'clear -x'
+alias g='git'
+alias ls 'lsd --icon=always'
+alias --save gwip "git add --all && git commit -am 'WIP'"
+alias -- ll 'ls -l'
+alias 'k=kubectl get'
+alias gc git commit --verbose
+# alias hidden 'not found'
+alias c 'echo hi' # trailing comment
+`
+	expected := map[string]string{
+		"clear": "clear -x",
+		"g":     "git",
+		"ls":    "lsd --icon=always",
+		"gwip":  "git add --all && git commit -am 'WIP'",
+		"ll":    "ls -l",
+		"k":     "kubectl get",
+		"gc":    "git commit --verbose",
+		"c":     "echo hi",
+	}
+
+	got, _ := ParseFishConfig("", input)
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("ParseFishConfig() aliases = %#v; want %#v", got, expected)
+	}
+}
+
+func TestParseFishConfigAbbrForms(t *testing.T) {
+	input := `
+abbr -a gl git log
+abbr --add gco 'git checkout'
+abbr gp git push
+abbr -a -- xg4 'git commit -m'
+abbr -a --position anywhere L '| less'
+abbr -a --set-cursor gcm "git commit -m '%'"
+abbr -a -g gd git diff
+abbr -a --regex '[0-9]+' dynamic something
+abbr -a --function expand_dots dots
+abbr --erase gone
+abbr --rename old new
+abbr -a '!$' '$history[1]'
+abbr -a --command git -- pull 'git pull'
+abbr -a --command $tool -- \
+    (string split -f1 -m1 ' ' -- $entry) \
+    (string split -f2 -m1 ' ' -- $entry)
+`
+	expected := map[string]string{
+		"gl":   "git log",
+		"gco":  "git checkout",
+		"gp":   "git push",
+		"xg4":  "git commit -m",
+		"L":    "| less",
+		"gcm":  "git commit -m '%'",
+		"gd":   "git diff",
+		"!$":   "$history[1]",
+		"pull": "git pull",
+	}
+
+	_, got := ParseFishConfig("", input)
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("ParseFishConfig() abbrs = %#v; want %#v", got, expected)
+	}
+}
+
+func TestParseFishConfigPrefersFirstConditionalArm(t *testing.T) {
+	// `end` closes every kind of fish block, so the inner `for` and `function`
+	// must not pop the enclosing `if` and let the fallback arm win.
+	input := `
+if type -q lsd
+    for f in a b
+        echo $f
+    end
+    alias ls 'lsd --icons'
+    alias lt 'lsd --tree'
+else
+    alias ls 'ls --color=auto'
+    alias lt 'tree'
+end
+
+function greet
+    echo hi
+end
+
+switch (uname)
+    case Darwin
+        alias o 'open'
+    case Linux
+        alias o 'xdg-open'
+end
+
+alias g 'git'
+`
+	expected := map[string]string{
+		"ls": "lsd --icons",
+		"lt": "lsd --tree",
+		"o":  "open",
+		"g":  "git",
+	}
+
+	got, _ := ParseFishConfig("", input)
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("ParseFishConfig() aliases = %#v; want %#v", got, expected)
+	}
+}
+
+func TestParseFishConfigStatementSeparators(t *testing.T) {
+	input := `
+type -q eza; and alias ls 'eza --icons'
+type -q bat; or alias cat 'bat --plain'
+alias a 'echo a'; alias b 'echo b'
+command alias c 'echo c'
+`
+	expected := map[string]string{
+		"ls":  "eza --icons",
+		"cat": "bat --plain",
+		"a":   "echo a",
+		"b":   "echo b",
+		"c":   "echo c",
+	}
+
+	got, _ := ParseFishConfig("", input)
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("ParseFishConfig() aliases = %#v; want %#v", got, expected)
+	}
+}
+
+func TestParseFishConfigReadsSavedAliasFunctions(t *testing.T) {
+	// The exact shape `alias --save` writes, in both the space and equals forms
+	// fish has used for the description.
+	input := `
+function gst --wraps='git status -sb' --description 'alias gst git status -sb'
+    git status -sb $argv
+end
+
+function g --wraps='git status' --description 'alias g=git status'
+    git status $argv
+end
+
+function lsd --description 'alias lsd lsd --icon=always'
+    command lsd --icon=always $argv
+end
+
+function greet --description 'say hello'
+    echo hello
+end
+`
+	expected := map[string]string{
+		"gst": "git status -sb",
+		"g":   "git status",
+		"lsd": "lsd --icon=always",
+	}
+
+	got, _ := ParseFishConfig("", input)
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("ParseFishConfig() aliases = %#v; want %#v", got, expected)
+	}
+}
+
+func TestScanFishDefsCoversAutoloadedDirs(t *testing.T) {
+	dir := t.TempDir()
+	writeFish(t, filepath.Join(dir, "config.fish"), "alias g 'git'\nabbr -a gl git log\n")
+	writeFish(t, filepath.Join(dir, "conf.d", "10-tools.fish"), "alias k 'kubectl'\nabbr -a kg 'kubectl get'\n")
+	writeFish(t, filepath.Join(dir, "functions", "gst.fish"),
+		"function gst --wraps='git status' --description 'alias gst git status'\n    git status $argv\nend\n")
+
+	defs := scanFishDefs(dir)
+
+	wantAliases := map[string]string{"g": "git", "k": "kubectl", "gst": "git status"}
+	if !reflect.DeepEqual(defs.aliases, wantAliases) {
+		t.Errorf("scanFishDefs() aliases = %#v; want %#v", defs.aliases, wantAliases)
+	}
+	wantAbbrs := map[string]string{"gl": "git log", "kg": "kubectl get"}
+	if !reflect.DeepEqual(defs.abbrs, wantAbbrs) {
+		t.Errorf("scanFishDefs() abbrs = %#v; want %#v", defs.abbrs, wantAbbrs)
+	}
+}
+
+func TestScanFishDefsPrefersConfigOverAutoloadedFunction(t *testing.T) {
+	// An autoloaded function never runs while the name is already defined, so
+	// config.fish is what the shell actually ends up with.
+	dir := t.TempDir()
+	writeFish(t, filepath.Join(dir, "config.fish"), "alias gst 'git status -sb'\n")
+	writeFish(t, filepath.Join(dir, "functions", "gst.fish"),
+		"function gst --description 'alias gst git status'\n    git status $argv\nend\n")
+
+	if got := scanFishDefs(dir).aliases["gst"]; got != "git status -sb" {
+		t.Errorf("scanFishDefs() gst = %q; want %q", got, "git status -sb")
+	}
+}
+
+func TestScanFishDefsFollowsSource(t *testing.T) {
+	dir := t.TempDir()
+	sourced := filepath.Join(dir, "aliases.fish")
+	writeFish(t, sourced, "alias v 'nvim'\n")
+	writeFish(t, filepath.Join(dir, "config.fish"),
+		"source \""+sourced+"\"\nsource (fzf --fish | psub)\nsource \"$IRIS_MISSING_VAR/x.fish\"\n")
+
+	got := scanFishDefs(dir).aliases
+	if !reflect.DeepEqual(got, map[string]string{"v": "nvim"}) {
+		t.Errorf("scanFishDefs() aliases = %#v; want v=nvim only", got)
+	}
+}
+
+func TestScanFishDefsResolvesLoopSourcedFiles(t *testing.T) {
+	// A config that names its parts in a `set` list and sources them from a
+	// `for` loop reaches every alias only if both are resolved.
+	dir := t.TempDir()
+	writeFish(t, filepath.Join(dir, "config", "aliases.fish"), "alias g 'git'\n")
+	writeFish(t, filepath.Join(dir, "config", "abbr.fish"), "abbr -a gl git log\n")
+	writeFish(t, filepath.Join(dir, "config", "prompt.fish"), "alias p 'starship prompt'\n")
+	writeFish(t, filepath.Join(dir, "config.fish"), `
+source "$__fish_config_dir/config/prompt.fish"
+
+function __source_fish_config_files
+    set -l files \
+        aliases \
+        abbr
+
+    for file in $files
+        set -l config_file "$__fish_config_dir/config/$file.fish"
+        path is -f -- "$config_file"; and source "$config_file"
+    end
+end
+
+__source_fish_config_files
+`)
+
+	defs := scanFishDefs(dir)
+
+	wantAliases := map[string]string{"g": "git", "p": "starship prompt"}
+	if !reflect.DeepEqual(defs.aliases, wantAliases) {
+		t.Errorf("scanFishDefs() aliases = %#v; want %#v", defs.aliases, wantAliases)
+	}
+	if !reflect.DeepEqual(defs.abbrs, map[string]string{"gl": "git log"}) {
+		t.Errorf("scanFishDefs() abbrs = %#v; want gl=git log", defs.abbrs)
+	}
+}
+
+func TestScanFishDefsInvalidatesOnNewConfDFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFish(t, filepath.Join(dir, "config.fish"), "alias g 'git'\n")
+	writeFish(t, filepath.Join(dir, "conf.d", "10-tools.fish"), "alias k 'kubectl'\n")
+
+	if got := len(scanFishDefs(dir).aliases); got != 2 {
+		t.Fatalf("scanFishDefs() = %d aliases; want 2", got)
+	}
+
+	// A file appearing in conf.d/ leaves every scanned file byte-identical, so
+	// only the directory stamp can catch it.
+	added := filepath.Join(dir, "conf.d", "20-more.fish")
+	writeFish(t, added, "alias d 'docker'\n")
+	if err := os.Chtimes(filepath.Join(dir, "conf.d"), time.Now().Add(time.Second), time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+
+	got := scanFishDefs(dir).aliases
+	if got["d"] != "docker" {
+		t.Errorf("scanFishDefs() after adding %s = %#v; want d=docker", added, got)
+	}
+}
+
+func TestScanFishDefsReturnsAnIndependentCopy(t *testing.T) {
+	dir := t.TempDir()
+	writeFish(t, filepath.Join(dir, "config.fish"), "alias g 'git'\nabbr -a gl git log\n")
+
+	defs := scanFishDefs(dir)
+	defs.aliases["injected"] = "nope"
+	defs.abbrs["injected"] = "nope"
+
+	again := scanFishDefs(dir)
+	if len(again.aliases) != 1 || len(again.abbrs) != 1 {
+		t.Errorf("cache returned a mutable reference: %#v", again)
+	}
+}
+
+func TestFishAdapterImplementsAbbrScanner(t *testing.T) {
+	if _, ok := Adapter(&FishAdapter{}).(AbbrScanner); !ok {
+		t.Error("FishAdapter does not implement AbbrScanner")
+	}
+	for _, a := range []Adapter{&BashAdapter{}, &ZshAdapter{}} {
+		if _, ok := a.(AbbrScanner); ok {
+			t.Errorf("%s implements AbbrScanner; only fish has abbreviations", a.GetName())
+		}
+	}
+}
+
+func writeFish(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/scoring/scorer.go
+++ b/internal/scoring/scorer.go
@@ -144,7 +144,7 @@ func basePriorityFor(s spec.Suggestion) int {
 	}
 
 	switch s.Source {
-	case "spec":
+	case "spec", "abbr":
 		return 60
 	case "ai":
 		if s.Confidence > 0 {

--- a/spec/lookup.go
+++ b/spec/lookup.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	ShellAliases   = map[string]string{}
+	ShellAbbrs     = map[string]string{}
 	shellAliasesMu sync.RWMutex
 )
 
@@ -38,17 +39,23 @@ func GetAliasesCopy() map[string]string {
 func Lookup(input string) []Suggestion {
 	if shell.Current != nil {
 		aliases := shell.Current.ScanAliases()
+		abbrs := map[string]string{}
+		if scanner, ok := shell.Current.(shell.AbbrScanner); ok {
+			abbrs = scanner.ScanAbbrs()
+		}
 		shellAliasesMu.Lock()
 		ShellAliases = aliases
+		ShellAbbrs = abbrs
 		shellAliasesMu.Unlock()
 	}
 
 	shellAliasesMu.RLock()
 	aliases := ShellAliases
+	abbrs := ShellAbbrs
 	shellAliasesMu.RUnlock()
 
 	if input == "" {
-		return topLevelSuggestions("", aliases)
+		return topLevelSuggestions("", aliases, abbrs)
 	}
 
 	tokens := Tokenize(input)
@@ -57,7 +64,7 @@ func Lookup(input string) []Suggestion {
 	expandedPrefix := ""
 
 	if len(tokens) == 1 && tokens[0] == "" {
-		return topLevelSuggestions("", aliases)
+		return topLevelSuggestions("", aliases, abbrs)
 	}
 	// NOTE: remember that wrapper already check if we type nothing, but I just want to make sure
 	// in the future, maybe we will write unit test or using Lookup in another module
@@ -121,7 +128,7 @@ func Lookup(input string) []Suggestion {
 
 	if len(tokens) == 1 {
 		query := tokens[0]
-		results := topLevelSuggestions(query, aliases)
+		results := topLevelSuggestions(query, aliases, abbrs)
 
 		if spec, exists := Registry[query]; exists {
 			hasTrailingSpace := query != "" && query[len(query)-1] == ' '
@@ -373,8 +380,8 @@ func Lookup(input string) []Suggestion {
 
 	if isAliasExpanded && expandedPrefix != "" && originalPrefix != "" {
 		for i := range results {
-			if strings.HasPrefix(results[i].Cmd, expandedPrefix) {
-				results[i].Cmd = originalPrefix + strings.TrimPrefix(results[i].Cmd, expandedPrefix)
+			if after, ok := strings.CutPrefix(results[i].Cmd, expandedPrefix); ok {
+				results[i].Cmd = originalPrefix + after
 			}
 		}
 	}
@@ -382,7 +389,7 @@ func Lookup(input string) []Suggestion {
 	return results
 }
 
-func topLevelSuggestions(query string, aliases map[string]string) []Suggestion {
+func topLevelSuggestions(query string, aliases, abbrs map[string]string) []Suggestion {
 	scanExternalCommands()
 	results, seen := []Suggestion{}, make(map[string]bool)
 
@@ -390,6 +397,15 @@ func topLevelSuggestions(query string, aliases map[string]string) []Suggestion {
 		if !seen[name] && (query == "" || HasPrefix(name, query)) {
 			results = append(results, Suggestion{
 				Cmd: name, Desc: target, Icon: "alias",
+			})
+			seen[name] = true
+		}
+	}
+
+	for name, expansion := range abbrs {
+		if !seen[name] && (query == "" || HasPrefix(name, query)) {
+			results = append(results, Suggestion{
+				Cmd: name, Desc: expansion, Icon: "abbr", Source: "abbr",
 			})
 			seen[name] = true
 		}


### PR DESCRIPTION
closes #153

`FishAdapter.ScanAliases` sent `config.fish` through `ScanPosixAliases`, which reads bash/zsh syntax, so on a normal fish config you get almost nothing back and what you do get can be wrong. `abbr` wasn't read at all

```
alias clear 'clear -x'
abbr -a gl git log
if type -q lsd
    alias ls 'lsd --icon=always'
else
    alias ls 'ls --color=auto'
end
alias g='git'

before:  map[string]string{"'lsd --icon":"always'"}
after:   aliases map[clear:clear -x  g:git  ls:lsd --icon=always]
         abbrs   map[gl:git log]
```

The four problems from the issue, plus one that only showed up against a real config:

- `alias name value` has no `=` to split on so those lines were dropped, and when the value carried its own `=` the line survived but split in the wrong place. Both forms parse now, with `-s`/`--save` and `--` handled (1dd9d53)
- blocks were counted with `if`/`else`/`fi`. fish closes everything with `end`, and that includes `for`/`while`/`switch`/`begin`/`function`, so counting only `if` lets an inner `end` pop the enclosing one and the fallback arm starts overwriting the preferred one. It's a stack now, first arm still wins, `switch`/`case` included (1dd9d53)
- only `config.fish` was read. Now `functions/*.fish`, `conf.d/*.fish` and `config.fish`, in that precedence order, since an autoloaded function only loads while its name is still undefined. `$__fish_config_dir` is resolved once per process, same trick as `ZDOTDIR` (1dd9d53)
- `abbr` parses in the forms people write: `-a`/`--add`, implicit add, `--`, `--position`, `--set-cursor`, `-g`. `--regex` and `--function` are skipped since neither the name nor the expansion is in the text, and a name the shell computes gets dropped instead of recorded as a literal. They reach the menu with their own source and icon, which fits the split from #60 (6cec6ff)
- the fifth one: following `source` needed `set` and `for` resolved too. My own config names its parts in a list and sources them from a loop, so without that the parser never reaches a single alias file (1dd9d53)

```fish
for file in $files
    set -l config_file "$__fish_config_dir/config/$file.fish"
    path is -f -- "$config_file"; and source "$config_file"
end
```

The walker was split out first (d8fa4a1) so the posix path and the fish one share the source following and cache stamping instead of duplicating both

> [!NOTE]
> aliases and abbrs come out of one walk and share one cache entry. Two scans with different entry points would evict each other and re-read the whole tree on every keystroke

abbrs aren't wired into `core.expand-alias`: fish expands them itself on space, and a `--set-cursor` abbr would get its marker typed literally

`integration/shell/fish_test.go` covers the alias and abbr forms, arm preference with nested blocks, statement separators, `alias --save` function files, the autoloaded dirs, loop-sourced files, and cache invalidation when a file lands in `conf.d/`. Against my real config it finds 27/27 aliases and 39/39 plain abbrs; the other 50 are the `--command`-scoped ones built by that loop with `(string split ...)` names, which no static parser can resolve. `just test`, `just lint` and `go vet ./...` are clean
