### PR TITLE
ci(nix): verify flake builds on go/nix changes

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,41 @@
+name: Nix
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "go.mod"
+      - "go.sum"
+      - "**/*.go"
+      - ".github/workflows/nix.yml"
+  pull_request:
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "go.mod"
+      - "go.sum"
+      - "**/*.go"
+      - ".github/workflows/nix.yml"
+
+jobs:
+  build:
+    name: Flake Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Build flake package
+        run: nix build .#default -L

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
               subPackages = ["cmd/iris"];
 
               proxyVendor = true;
-              vendorHash = "sha256-q1szUQkhdKq2VhMuWYYWTahmDxGeVjvHLmjciZu3cBU=";
+              vendorHash = "sha256-huyTWK6ef42KY2zmFIQuFoeR8B8XKHE7OVfFnfefeCU=";
 
               doCheck = false;
 


### PR DESCRIPTION
this fixes the current stale `vendorHash`, and adds a ci workflow to detect the need for updating it early and avoid prs like #99, #132, and this one in the future.